### PR TITLE
Fix: Prevent danmu stopping at high speeds and align speed limits

### DIFF
--- a/danmu-desktop/renderer.js
+++ b/danmu-desktop/renderer.js
@@ -44,7 +44,11 @@ function showdanmu(
   const maxTime = 15000; // 最慢速度 (20秒)
   const minTime = 2000; // 最快速度 (2秒)
   const timeRange = maxTime - minTime;
-  const duration = maxTime - (timeRange / 10) * (speed - 1);
+  let duration = maxTime - (timeRange / 10) * (speed - 1);
+
+  if (duration < minTime) {
+    duration = minTime;
+  }
 
   danmu.animate(
     [

--- a/server/app.py
+++ b/server/app.py
@@ -54,7 +54,7 @@ ws_clients = set()
 
 # Define setting ranges
 SETTING_RANGES = {
-    "Speed": {"min": 1, "max": 20},
+    "Speed": {"min": 1, "max": 11},
     "Opacity": {"min": 0, "max": 100},
     "FontSize": {"min": 12, "max": 100},
 }


### PR DESCRIPTION
Problem:
When the server-configured speed was 13 or higher, the client-side danmu animation calculation in `danmu-desktop/renderer.js` resulted in a negative animation duration. This caused the danmu to appear stuck on the left side of the screen.

Solution:
1. Client-side (`danmu-desktop/renderer.js`):
   - I modified the `showdanmu` function to ensure the calculated animation `duration` does not fall below `minTime` (2000ms). If the calculation results in a lower value (e.g., for speeds > 11), `duration` is set to `minTime`.
   - I changed `const duration` to `let duration` to allow this modification.

2. Server-side (`server/app.py`):
   - I adjusted the `SETTING_RANGES` for the "Speed" parameter. The maximum allowed speed is now 11 (down from 20). This aligns the server's speed configuration with the client's animation design, where speed 11 corresponds to the `minTime` duration.

This ensures that danmu animations remain fluid even if high speed values are (theoretically) received by the client, and the server's configuration is now more consistent with the client's capabilities.