### PR TITLE
fix: Correct macOS ARM64 artifact handling in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,10 +71,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          APP_VERSION: ${{ needs.check_version_change.outputs.version }}
         run: |
           cd danmu-desktop
           npm run build:webpack
-          npx electron-builder --config.extraMetadata.version=${{ needs.check_version_change.outputs.version }}
+
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            npx electron-builder --linux --config.extraMetadata.version=$APP_VERSION
+          elif [ "$RUNNER_OS" == "Windows" ]; then
+            npx electron-builder --win --config.extraMetadata.version=$APP_VERSION
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            npx electron-builder --mac --arm64 --config.extraMetadata.version=$APP_VERSION
+          fi
+
+          echo "Listing packaged files in danmu-desktop/pack:"
+          ls -R pack
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
@@ -198,16 +209,34 @@ jobs:
       - name: Find DMG file
         if: matrix.os == 'macos-latest' && (needs.check_version_change.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch')
         id: find_dmg
+        env: # Add APP_VERSION to env
+          APP_VERSION: ${{ needs.check_version_change.outputs.version }}
         run: |
-          DMG_PATH=$(find danmu-desktop/pack -name "danmu manager*-*.dmg" -type f)
-          echo "dmg_path=$DMG_PATH" >> "$GITHUB_ENV"
+          EXPECTED_DMG="danmu-desktop/pack/danmu manager-${APP_VERSION}-mac-arm64.dmg"
+          if [ -f "$EXPECTED_DMG" ]; then
+            echo "Found DMG: $EXPECTED_DMG"
+            echo "dmg_path=$EXPECTED_DMG" >> "$GITHUB_ENV"
+          else
+            echo "Error: Expected DMG file $EXPECTED_DMG not found."
+            ls -R danmu-desktop/pack # List available files for debugging
+            exit 1
+          fi
 
       - name: Find ZIP file
         if: matrix.os == 'macos-latest' && (needs.check_version_change.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch')
         id: find_zip
+        env: # Add APP_VERSION to env
+          APP_VERSION: ${{ needs.check_version_change.outputs.version }}
         run: |
-          ZIP_PATH=$(find danmu-desktop/pack -name "danmu manager*-*.zip" -type f)
-          echo "zip_path=$ZIP_PATH" >> "$GITHUB_ENV"
+          EXPECTED_ZIP="danmu-desktop/pack/danmu manager-${APP_VERSION}-mac-arm64.zip"
+          if [ -f "$EXPECTED_ZIP" ]; then
+            echo "Found ZIP: $EXPECTED_ZIP"
+            echo "zip_path=$EXPECTED_ZIP" >> "$GITHUB_ENV"
+          else
+            echo "Error: Expected ZIP file $EXPECTED_ZIP not found."
+            ls -R danmu-desktop/pack # List available files for debugging
+            exit 1
+          fi
 
       - name: Upload DMG
         if: matrix.os == 'macos-latest' && (needs.check_version_change.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch')


### PR DESCRIPTION
Addresses "Validation Failed" error during macOS release asset upload.

Changes:
- Modified the GitHub Actions workflow (`.github/workflows/build.yml`):
  - The "Build Electron App" step now explicitly invokes `electron-builder --mac --arm64` for macOS runners to ensure an ARM64 build.
  - Added a step after the build to list generated artifacts for easier debugging.
  - Updated "Find DMG file" and "Find ZIP file" steps for macOS to:
    - Expect exact filenames (e.g., `danmu manager-${APP_VERSION}-mac-arm64.dmg`).
    - Check for the file's existence and fail with an error (including the output from listing generated artifacts) if not found.
    - Pass the correct `APP_VERSION` environment variable.
- Ensured `asset_name` in upload steps matches the expected ARM64 artifact name.

These changes aim to ensure that the correct ARM64 artifacts are built and found, resolving the upload validation issue.