### PR TITLE
fix: Specify bash shell for build script in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,7 @@ jobs:
           npm install
 
       - name: Build Electron App
+        shell: bash # This line is added
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
The conditional logic in the "Build Electron App" step of the GitHub Actions workflow was written using bash syntax. This caused a ParserError on Windows runners, where the default shell is PowerShell.

This commit adds `shell: bash` to this specific step in `.github/workflows/build.yml` to ensure the script is executed by bash across all operating systems in the build matrix (Linux, macOS, and Windows). This will allow the conditional execution of electron-builder commands to function correctly on all platforms.