### PR TITLE
Fix: Danmu not displaying in child windows

### DIFF
--- a/danmu-desktop/child.css
+++ b/danmu-desktop/child.css
@@ -19,7 +19,7 @@ body {
   overflow: hidden;
 }
 h1::before {
-  content: attr(data-storke);
+  content: attr(data-stroke);
 }
 h1::before {
   position: absolute;


### PR DESCRIPTION
The danmu were not being displayed due to a `TypeError: window.showdanmu is not a function` occurring in the child overlay windows. This happened because the `showdanmu` function, defined in `renderer.js` and bundled into `renderer.bundle.js`, was not reliably available in the global `window` scope when the WebSocket message handler attempted to call it.

This commit addresses the issue by:
1. Modifying the WebSocket message handler (injected script in `main.js`) to poll for `window.showdanmu` and retry if it's not immediately available. This made the underlying problem visible.
2. Explicitly attaching the `showdanmu` function to `window.showdanmu` in `renderer.js` to ensure it is correctly exposed in the global scope of the child windows.

Additionally, the following improvements were made during debugging:
- Corrected a typo from `data-storke` to `data-stroke` in `renderer.js` and `child.css`.
- Enhanced logging in both the `showdanmu` function (`renderer.js`) and the WebSocket message handler (`main.js`) for easier debugging.
- Made the danmu animation speed-to-duration calculation in `renderer.js` more robust.