### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,10 @@
 name: Build Electron App
 
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/guan4tou2/danmu-desktop/security/code-scanning/2](https://github.com/guan4tou2/danmu-desktop/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will define the minimum required permissions for the entire workflow. Based on the workflow's operations, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `packages: write` for uploading release assets.
- `pull-requests: write` if the workflow interacts with pull requests (not explicitly seen here but included as a precaution).

The `permissions` block will be added at the root level, applying to all jobs in the workflow. If any job requires additional permissions, they can be overridden within the specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
