### PR TITLE
Potential fix for code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -321,7 +321,8 @@ def remove_from_blacklist():
         else:
             return make_response(json.dumps({"error": "Keyword not found"}), 404, {"Content-Type": "application/json"})
     except Exception as e:
-        return make_response(json.dumps({"error": str(e)}), 500, {"Content-Type": "application/json"})
+        print(f"Error occurred: {sanitize_log_string(str(e))}")  # Log the sanitized exception details
+        return make_response(json.dumps({"error": "An internal error has occurred"}), 500, {"Content-Type": "application/json"})
 
 
 @app.route("/admin/blacklist/get", methods=["GET"])
@@ -344,13 +345,13 @@ def check_connections():
                         # Send a ping message to check connection
                         ws.send(json.dumps({"type": "ping"}))
                     except Exception as e:
-                        print(f"Connection dead, removing: {sanitize_log_string(str(e))}")
+                        print(f"Connection dead, removing: {sanitize_log_string(str(e))}")  # No changes needed here
                         active_connections.discard(ws)
                         if ws == active_ws:
                             active_ws = None
             time.sleep(30)  # Check every 30 seconds
         except Exception as e:
-            print(f"Error in connection check: {sanitize_log_string(str(e))}")
+            print(f"Error in connection check: {sanitize_log_string(str(e))}")  # No changes needed here
             time.sleep(30)
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/guan4tou2/danmu-desktop/security/code-scanning/8](https://github.com/guan4tou2/danmu-desktop/security/code-scanning/8)

To fix the issue, the code should log the detailed exception information on the server for debugging purposes while returning a generic error message to the client. This ensures that sensitive information is not exposed externally while still allowing developers to diagnose issues.

**Steps to fix:**
1. Replace the line that sends the exception details (`str(e)`) to the client with a generic error message.
2. Log the exception details on the server using a logging mechanism.
3. Ensure that the logging mechanism sanitizes sensitive information if necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
