### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through an exception

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -304,7 +304,8 @@ def add_to_blacklist():
         else:
             return make_response(json.dumps({"error": "Invalid keyword"}), 400, {"Content-Type": "application/json"})
     except Exception as e:
-        return make_response(json.dumps({"error": str(e)}), 500, {"Content-Type": "application/json"})
+        print(f"Error occurred: {sanitize_log_string(str(e))}")  # Log the sanitized exception details
+        return make_response(json.dumps({"error": "An internal error has occurred"}), 500, {"Content-Type": "application/json"})
 
 
 @app.route("/admin/blacklist/remove", methods=["POST"])


### PR DESCRIPTION
Potential fix for [https://github.com/guan4tou2/danmu-desktop/security/code-scanning/7](https://github.com/guan4tou2/danmu-desktop/security/code-scanning/7)

To fix the issue, the exception details should not be directly exposed to the client. Instead, log the sanitized exception details on the server for debugging purposes and return a generic error message to the client. This ensures that sensitive information is not leaked while still allowing developers to diagnose issues.

**Steps to fix:**
1. Replace the direct inclusion of `str(e)` in the response with a generic error message.
2. Log the sanitized exception details using the `sanitize_log_string` function for server-side debugging.
3. Ensure the client receives a consistent and generic error message, such as `"An internal error has occurred"`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
