### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -219,7 +219,7 @@ def fire():
 
     except Exception as e:
         print(f"Send Error: {sanitize_log_string(str(e))}")
-        return make_response(str(e), 500)
+        return make_response("An internal error has occurred.", 500)
 
 
 @app.route("/update", methods=["POST"])
@@ -257,7 +257,7 @@ def update():
         return make_response("OK", 200)
     except Exception as e:
         print(f"Error updating settings: {sanitize_log_string(str(e))}")
-        return make_response(str(e), 400)
+        return make_response("An error occurred while updating settings.", 400)
 
 
 @app.route("/admin/Set", methods=["POST"])


### PR DESCRIPTION
Potential fix for [https://github.com/guan4tou2/danmu-desktop/security/code-scanning/5](https://github.com/guan4tou2/danmu-desktop/security/code-scanning/5)

To fix the issue, we need to ensure that sensitive information from exceptions is not exposed to external users. Instead of returning the raw exception message (`str(e)`), we should return a generic error message to the user while logging the detailed exception information on the server for debugging purposes. This approach adheres to secure error-handling practices.

Steps to implement the fix:
1. Replace the `return make_response(str(e), 500)` statement with a generic error message, such as `"An internal error has occurred."`.
2. Ensure the detailed exception information is logged using the existing `sanitize_log_string` function to prevent sensitive data leakage in logs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
