### PR TITLE
Fix: Mitigate ReDoS vulnerabilities in regular expressions

### DIFF
--- a/danmu-desktop/renderer.js
+++ b/danmu-desktop/renderer.js
@@ -21,7 +21,7 @@ window.showdanmu = function(
 ) {
   console.log('[showdanmu] Received:', { string: sanitizeLog(string), opacity, color: sanitizeLog(color), size, speed });
   var parentElement = document.getElementById("danmubody");
-  var imgs = /^https?:\/\/\S*.(gif|png|jpeg|jpg)$/;
+  var imgs = /^https?:\/\/([^\s/]+\/)*[^\s/]+\.(gif|png|jpeg|jpg)$/i;
   // Add a check for http/https protocols
   var protocolCheck = /^(http:|https:)/i;
   if (imgs.test(string) && protocolCheck.test(string)) { // Added protocolCheck
@@ -119,7 +119,7 @@ startButton.addEventListener("click", () => {
   var ipre =
     /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
   var domainre =
-    /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
+    /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/i;
   var portre = /^\d{1,5}$/;
   if (
     ipre.test(ip.value) ||

--- a/server/app.py
+++ b/server/app.py
@@ -69,7 +69,7 @@ def sanitize_log_string(input_val):
 
 
 def is_valid_image_url(url):
-    return bool(re.match(r"https?://.*\.(jpeg|jpg|gif|png|webp)$", url, re.I))
+    return bool(re.match(r"https?://([^\s/]+/)*[^\s/]+\.(jpeg|jpg|gif|png|webp)$", url, re.I))
 
 
 # Internal communication: Forward messages to WebSocket server


### PR DESCRIPTION
Addresses potential regular expression denial of service (ReDoS) vulnerabilities and improves regex specificity based on CWE-1333, CWE-400, and CWE-730.

Changes made:

1.  In `danmu-desktop/renderer.js`:
    *   Modified the `imgs` regex for image URL validation to use a more
        specific path matching (`([^\s/]+\/)*[^\s/]+`) instead of `\S*`
        and added case-insensitivity.
        (Line 18: /^https?:\/\/([^\s\/]+\/)*[^\s\/]+\.(gif|png|jpeg|jpg)$/i)
    *   Modified the `domainre` regex for domain validation to a more
        standard and potentially safer pattern, and added case-insensitivity.
        (Line 113: /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/i)

2.  In `server/app.py`:
    *   Modified the regex for image URL validation in `is_image_url`
        function to replace `.*` with a more specific path matching
        `([^\s/]+/)*[^\s/]+` and ensured it implicitly anchors at the
        start and explicitly at the end with `re.match`.
        (Line 56: r"https?://([^\s/]+/)*[^\s/]+\.(jpeg|jpg|gif|png|webp)$")

Build and syntax checks for both the Electron application and the Python server passed after these changes.