### PR TITLE
Fix: Correct ws_handler signature to resolve TypeError

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -377,7 +377,7 @@ def run_ws_server():
         print(f"Client disconnected. Remaining clients: {len(clients)}")
 
     # Handle WebSocket connections from Danmu Desktop
-    async def ws_handler(websocket, path):
+    async def ws_handler(websocket):
         await register(websocket)
         try:
             async for message in websocket:


### PR DESCRIPTION
The ws_handler function within run_ws_server was defined to accept both `websocket` and `path` arguments. However, the websockets library, as used in this project, calls this handler with only the `websocket` argument. This mismatch caused a TypeError when a new WebSocket connection was established with the dedicated WebSocket server.

This commit updates the ws_handler signature to only accept the `websocket` argument. The `path` argument was not used within the function, so its removal does not affect any logic. This change aligns the handler's definition with its usage by websockets.serve, resolving the TypeError.