### PR TITLE
Fix: Grant contents:write permission for release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build Electron App
 
 permissions:
-  contents: read
+  contents: write
   packages: write
   pull-requests: write
 


### PR DESCRIPTION
The GitHub Actions workflow for creating releases was failing due to missing `contents: write` permission. This commit updates the workflow file to grant the necessary permission, allowing the workflow to create releases successfully.