### PR TITLE
fix(v4.6.3): storage persistence - /tmp default + plugin architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@
 
 ---
 
+## [4.6.3] - 2026-04-20
+
+### 修復 / Fixed
+
+- **SETTINGS_FILE 預設路徑 `/tmp`**：之前預設是 `tempfile.gettempdir()` 解析為 `/tmp`，macOS 重開機會清空（部分 Linux 發行版亦同），非 Docker 直跑的使用者每次開機都會 silently 丟失設定（顏色 / 透明度 / 速度 / 字型）。改為 `server/runtime/settings.json`，與其他 runtime state 同 dir。
+- **插件狀態與使用者插件可持久化**：重構 `PluginManager`，拆開**內建 example 插件**（`server/plugins/`，跟 image 一起升級）與**使用者自訂插件**（`server/user_plugins/`，獨立 mount）。`plugins_state.json` 移到 `server/runtime/`。一次性自動 migration：升級時若偵測到舊位置檔案則複製至新位置。
+
+### 新增 / Added
+
+- **`scripts/backup.sh`**：一鍵備份 runtime / user_plugins / user_fonts / static / .env 成 dated tarball。支援 `BACKUP_SKIP_STATIC=1` 環境變數跳過 bundled static 資源。
+- **`server/user_plugins/`**：使用者自訂插件放這裡；gitignored，可獨立 bind-mount。含 `README.md` 說明 SDK 路徑。
+
+### 改善 / Improved
+
+- `docker-compose.yml` 新增 `./server/user_plugins:/app/server/user_plugins` mount；不再 mount `./server/plugins`（避免 shadow bundled example plugins）。
+- `DEPLOYMENT.md` persistence table 更新為新的雙 plugin dir 架構 + legacy migration 說明。
+
+---
+
 ## [4.6.2] - 2026-04-20
 
 ### 修復 / Fixed

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -173,15 +173,19 @@ to the host by the default `docker-compose.yml`:
 | `./server/runtime/filter_rules.json` | `/app/server/runtime/filter_rules.json` | Blacklist + filter rules |
 | `./server/runtime/settings.json` | `/app/server/runtime/settings.json` | Admin UI setting state (color / speed / etc.) |
 | `./server/runtime/webhooks.json` | `/app/server/runtime/webhooks.json` | Registered webhooks |
+| `./server/runtime/plugins_state.json` | `/app/server/runtime/plugins_state.json` | Enabled/disabled plugins |
+| `./server/user_plugins/` | `/app/server/user_plugins/` | Custom user plugins (drop `.py` files here) |
 | `./server/user_fonts/` | `/app/server/user_fonts/` | Uploaded user fonts |
 | `./server/static/` | `/app/server/static/` | Uploaded stickers / emojis (plus bundled assets) |
 | `./server/logs/` | `/app/server/logs/` | Server logs (optional for backup) |
 
-**Not yet persisted:** Plugin enabled/disabled state (`server/plugins/plugins_state.json`)
-and any custom user plugins still reset on container recreate. Mounting the whole
-`server/plugins/` directory would shadow bundled example plugins, which would then
-miss upstream fixes. Fix requires splitting bundled vs user plugin paths in the
-plugin manager — tracked for v4.7.
+**Bundled example plugins** (`server/plugins/example_*.py`) are NOT mounted —
+they live inside the image so upstream fixes arrive with each image upgrade.
+Put custom plugins in `server/user_plugins/` instead.
+
+**Legacy migration:** Upgrading from v4.6.2 or earlier? On first run, the plugin
+manager detects `server/plugins/plugins_state.json` and copies it to the new
+`server/runtime/plugins_state.json` automatically — no manual action needed.
 
 The paths for filter / settings / webhooks are redirected into `./server/runtime/`
 via `FILTER_RULES_FILE`, `SETTINGS_FILE`, `WEBHOOKS_PATH` env vars in compose.
@@ -193,19 +197,17 @@ The user-generated bind-mounted paths in the table above are the source of
 truth. `server/logs/` is bind-mounted for operational access but can be
 omitted from backups unless you need audit / debug history.
 
-### Manual backup (tar)
+### Backup (scripts/backup.sh)
 
 ```bash
-tar -czf danmu-backup-$(date +%F).tar.gz \
-  server/runtime/ \
-  server/user_fonts/ \
-  server/static/ \
-  .env
+./scripts/backup.sh                        # writes danmu-backup-YYYY-MM-DD.tar.gz
+./scripts/backup.sh /path/to/output.tgz    # custom filename
+BACKUP_SKIP_STATIC=1 ./scripts/backup.sh   # skip bundled static assets
 ```
 
-> **Plugin state / custom plugins** — see the note in the persistence table.
-> Plugin state loss during container rebuild is a known limitation tracked
-> for v4.7 refactor.
+Snapshots: `server/runtime/`, `server/user_plugins/`, `server/user_fonts/`,
+`server/static/`, and `.env`.
+
 
 ### Restore
 

--- a/danmu-desktop/package.json
+++ b/danmu-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danmu-desktop",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "description": "Danmu overlay controller for live streaming",
   "main": "dist/main.bundle.js",
   "scripts": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,11 +44,12 @@ services:
       - ./server/static:/app/server/static
       - ./server/logs:/app/server/logs
       # Persisted runtime state — survives container recreate (upgrade-safe).
-      # Stored: filter_rules.json, settings.json, webhooks.json (paths set via env above).
-      # NOTE: plugin state + user plugins NOT yet mounted — mounting the whole
-      # server/plugins dir would shadow bundled example plugins from the image.
-      # Tracked for v4.7 refactor (split bundled vs user plugin paths).
+      # Contains filter_rules.json, settings.json, webhooks.json (via env vars
+      # above) and plugins_state.json (via PluginManager's _STATE_FILE).
       - ./server/runtime:/app/server/runtime
+      # Custom user plugins. Bundled example plugins stay inside the image at
+      # /app/server/plugins (not mounted) so upstream fixes arrive on upgrade.
+      - ./server/user_plugins:/app/server/user_plugins
     restart: unless-stopped
     deploy:
       resources:

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# backup.sh — snapshot Danmu Fire runtime state into a dated tarball.
+#
+# Covers everything documented in DEPLOYMENT.md § Data persistence:
+#   - server/runtime/  (filter_rules, settings, webhooks, plugins_state)
+#   - server/user_plugins/  (custom user plugin .py files)
+#   - server/user_fonts/  (uploaded user fonts)
+#   - server/static/  (uploaded stickers, emojis, plus bundled static assets)
+#   - .env  (deploy configuration)
+#
+# Usage:
+#   ./scripts/backup.sh                 # writes danmu-backup-YYYY-MM-DD.tar.gz
+#   ./scripts/backup.sh /path/to/out    # writes to a specific file
+#   BACKUP_SKIP_STATIC=1 ./scripts/backup.sh  # skip bundled static assets
+#
+# Restore: tar -xzf <file>.tar.gz  then restart the stack with the same
+# --profile (+ any -f override files) used at deploy time.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+OUT="${1:-danmu-backup-$(date +%F).tar.gz}"
+
+if [[ -d "$(dirname "$OUT")" ]]; then :; else
+  echo "ERROR: output directory does not exist: $(dirname "$OUT")" >&2
+  exit 1
+fi
+
+PATHS=(
+  "server/runtime"
+  "server/user_plugins"
+  "server/user_fonts"
+)
+
+# Bundled stickers/emojis live under server/static/ — backing them up is
+# usually desired but can be skipped if they're large and already in the image.
+if [[ "${BACKUP_SKIP_STATIC:-0}" != "1" ]]; then
+  PATHS+=("server/static")
+fi
+
+if [[ -f ".env" ]]; then
+  PATHS+=(".env")
+fi
+
+# Sanity check: warn on missing paths, skip from archive.
+EXIST_PATHS=()
+for p in "${PATHS[@]}"; do
+  if [[ -e "$p" ]]; then
+    EXIST_PATHS+=("$p")
+  else
+    echo "WARN: skipping missing path: $p" >&2
+  fi
+done
+
+if [[ ${#EXIST_PATHS[@]} -eq 0 ]]; then
+  echo "ERROR: no paths to back up. Is this a Danmu Fire checkout?" >&2
+  exit 1
+fi
+
+echo "Writing $OUT"
+tar -czf "$OUT" "${EXIST_PATHS[@]}"
+
+SIZE=$(du -h "$OUT" | cut -f1)
+echo "Done. $OUT ($SIZE)"
+echo "Contents:"
+tar -tzf "$OUT" | head -20
+TOTAL=$(tar -tzf "$OUT" | wc -l | tr -d ' ')
+echo "... ($TOTAL entries total)"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -63,8 +63,19 @@ echo "Writing $OUT"
 tar -czf "$OUT" "${EXIST_PATHS[@]}"
 
 SIZE=$(du -h "$OUT" | cut -f1)
-echo "Done. $OUT ($SIZE)"
-echo "Contents:"
-tar -tzf "$OUT" | head -20
 TOTAL=$(tar -tzf "$OUT" | wc -l | tr -d ' ')
-echo "... ($TOTAL entries total)"
+echo "Done. $OUT ($SIZE, $TOTAL entries)"
+echo "Preview (first 20):"
+# Read tar output into an array instead of `tar | head` — the latter breaks
+# under `set -o pipefail` because head closes the pipe early, sending SIGPIPE
+# to tar, which returns 141 and trips `set -e`.
+CONTENTS=()
+while IFS= read -r line; do
+  CONTENTS+=("$line")
+done < <(tar -tzf "$OUT")
+for entry in "${CONTENTS[@]:0:20}"; do
+  echo "  $entry"
+done
+if (( TOTAL > 20 )); then
+  echo "  ... ($((TOTAL - 20)) more)"
+fi

--- a/server/config.py
+++ b/server/config.py
@@ -1,6 +1,5 @@
 import os
 import secrets
-import tempfile
 from pathlib import Path
 
 from dotenv import find_dotenv, load_dotenv
@@ -104,9 +103,12 @@ class Config:
     # Danmu history configuration
     DANMU_HISTORY_MAX_RECORDS = int(os.getenv("DANMU_HISTORY_MAX_RECORDS", "10000"))
     DANMU_HISTORY_CLEANUP_HOURS = int(os.getenv("DANMU_HISTORY_CLEANUP_HOURS", "24"))
+    # Default settings file lives alongside other runtime state under
+    # server/runtime/. Previously used /tmp which is wiped on reboot on
+    # many systems (macOS default, some Linux), silently losing user settings.
     SETTINGS_FILE = os.getenv(
         "SETTINGS_FILE",
-        str(Path(tempfile.gettempdir()) / "danmu_runtime_settings.json"),
+        str(Path(__file__).parent / "runtime" / "settings.json"),
     )
 
     # Scheduler configuration

--- a/server/config.py
+++ b/server/config.py
@@ -39,7 +39,7 @@ class Config:
     # Priority: runtime hash file > ADMIN_PASSWORD_HASHED env var > plaintext ADMIN_PASSWORD
     ADMIN_PASSWORD_HASHED = load_runtime_hash() or os.getenv("ADMIN_PASSWORD_HASHED", "")
     APP_NAME = "Danmu Fire"
-    APP_VERSION = "4.6.2"
+    APP_VERSION = "4.6.3"
     PORT = int(os.getenv("PORT", "4000"))
     WS_PORT = int(os.getenv("WS_PORT", "4001"))
     ENV = os.getenv("ENV", "development").lower()

--- a/server/managers/settings.py
+++ b/server/managers/settings.py
@@ -1,9 +1,10 @@
 import copy
 import json
 import os
-import tempfile
 import threading
 from pathlib import Path
+
+from server.config import Config
 
 _DEFAULT_OPTIONS = {
     "Color": [True, 0, 0, "#FFFFFF"],
@@ -26,8 +27,10 @@ class SettingsStore:
         self._lock = threading.Lock()
         self._options = copy.deepcopy(_DEFAULT_OPTIONS)
         self._ranges = _RANGES
-        default_path = Path(tempfile.gettempdir()) / "danmu_runtime_settings.json"
-        self._settings_file = Path(os.getenv("SETTINGS_FILE", str(default_path)))
+        # Read env at runtime so tests can monkeypatch after import; fall
+        # back to Config.SETTINGS_FILE (which has the sane server/runtime/
+        # default baked in).
+        self._settings_file = Path(os.environ.get("SETTINGS_FILE") or Config.SETTINGS_FILE)
         self._load_from_disk()
 
     def _load_from_disk(self):

--- a/server/services/plugin_manager.py
+++ b/server/services/plugin_manager.py
@@ -22,8 +22,18 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
-_PLUGINS_DIR = Path(__file__).parent.parent / "plugins"
-_STATE_FILE = _PLUGINS_DIR / "plugins_state.json"
+_SERVER_DIR = Path(__file__).parent.parent
+# Bundled example plugins shipped with the server image. Read-only intent —
+# upgrades should surface new example plugins without user action.
+_BUNDLED_PLUGINS_DIR = _SERVER_DIR / "plugins"
+# User-added plugins. Gitignored on the host, bind-mountable in Docker so
+# custom plugins survive image upgrades.
+_USER_PLUGINS_DIR = _SERVER_DIR / "user_plugins"
+# Enabled/disabled state lives in the persisted runtime/ dir so it survives
+# container recreate. Legacy path (plugins/plugins_state.json) is migrated
+# on first load — see _load_state().
+_STATE_FILE = _SERVER_DIR / "runtime" / "plugins_state.json"
+_LEGACY_STATE_FILE = _BUNDLED_PLUGINS_DIR / "plugins_state.json"
 _SCAN_INTERVAL = 5.0
 _HOOK_TIMEOUT = 3.0
 
@@ -120,8 +130,25 @@ class PluginManager:
     # ---- persistence -------------------------------------------------------
 
     def _load_state(self) -> Dict[str, bool]:
-        """Load enabled/disabled state from disk."""
+        """Load enabled/disabled state from disk.
+
+        One-time migration: if the legacy state file (next to bundled plugins)
+        exists and the new runtime location does not, copy the legacy content
+        so users upgrading from v4.6.2 or earlier don't lose toggles.
+        """
         try:
+            if not _STATE_FILE.exists() and _LEGACY_STATE_FILE.exists():
+                try:
+                    _STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+                    _STATE_FILE.write_bytes(_LEGACY_STATE_FILE.read_bytes())
+                    logger.info(
+                        "[PluginManager] Migrated legacy state %s -> %s",
+                        _LEGACY_STATE_FILE,
+                        _STATE_FILE,
+                    )
+                except Exception as exc:
+                    logger.warning("[PluginManager] Legacy state migration failed: %s", exc)
+
             if _STATE_FILE.exists():
                 with open(_STATE_FILE, encoding="utf-8") as f:
                     data = json.load(f)
@@ -135,7 +162,7 @@ class PluginManager:
         """Persist enabled/disabled state to disk. Caller must hold _lock."""
         state = {name: entry.enabled for name, entry in self._plugins.items()}
         try:
-            _PLUGINS_DIR.mkdir(exist_ok=True)
+            _STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
             tmp = _STATE_FILE.with_suffix(".tmp")
             with open(tmp, "w", encoding="utf-8") as f:
                 json.dump(state, f, indent=2)
@@ -180,10 +207,22 @@ class PluginManager:
                     return None
         return None
 
+    def _scan_dirs(self, explicit_dir: Optional[str] = None) -> List[Path]:
+        """Return the list of directories to scan for plugin .py files.
+
+        If *explicit_dir* is passed (tests), only that directory is scanned.
+        Otherwise scan bundled + user dirs in that order; a plugin name
+        appearing in both prefers the user version (loaded later overwrites).
+        """
+        if explicit_dir:
+            return [Path(explicit_dir)]
+        return [_BUNDLED_PLUGINS_DIR, _USER_PLUGINS_DIR]
+
     def load_all(self, plugins_dir: Optional[str] = None) -> None:
-        """Scan *plugins_dir* for .py plugin files and load them."""
-        scan_dir = Path(plugins_dir) if plugins_dir else _PLUGINS_DIR
-        scan_dir.mkdir(exist_ok=True)
+        """Scan bundled + user plugin dirs for .py files and load them."""
+        scan_dirs = self._scan_dirs(plugins_dir)
+        for d in scan_dirs:
+            d.mkdir(parents=True, exist_ok=True)
         self._state = self._load_state()
 
         with self._lock:
@@ -191,26 +230,28 @@ class PluginManager:
             self._mtime_map.clear()
             self._path_to_name.clear()
 
-        for py_file in sorted(scan_dir.glob("*.py")):
-            if py_file.name.startswith("_"):
-                continue
-            instance = self._load_plugin_from_file(py_file)
-            if instance is None:
-                continue
-            name = instance.name
-            mtime = py_file.stat().st_mtime
-            enabled = self._state.get(name, True)
-            entry = _PluginEntry(instance, str(py_file), mtime, enabled)
-            with self._lock:
-                self._plugins[name] = entry
-                self._mtime_map[str(py_file)] = mtime
-                self._path_to_name[str(py_file)] = name
-            logger.info(
-                "[PluginManager] Loaded plugin: %s v%s (%s)",
-                name,
-                instance.version,
-                "enabled" if enabled else "disabled",
-            )
+        for scan_dir in scan_dirs:
+            for py_file in sorted(scan_dir.glob("*.py")):
+                if py_file.name.startswith("_"):
+                    continue
+                instance = self._load_plugin_from_file(py_file)
+                if instance is None:
+                    continue
+                name = instance.name
+                mtime = py_file.stat().st_mtime
+                enabled = self._state.get(name, True)
+                entry = _PluginEntry(instance, str(py_file), mtime, enabled)
+                with self._lock:
+                    self._plugins[name] = entry
+                    self._mtime_map[str(py_file)] = mtime
+                    self._path_to_name[str(py_file)] = name
+                logger.info(
+                    "[PluginManager] Loaded plugin: %s v%s (%s) from %s",
+                    name,
+                    instance.version,
+                    "enabled" if enabled else "disabled",
+                    scan_dir.name,
+                )
 
         with self._lock:
             self._last_scan = time.monotonic()
@@ -264,14 +305,15 @@ class PluginManager:
             self._scan_lock.release()
 
     def _hot_scan(self) -> None:
-        """Re-scan plugins directory, reload changed files, remove deleted ones."""
-        scan_dir = _PLUGINS_DIR
-        if not scan_dir.is_dir():
-            return
-
-        current_files = {
-            str(p): p for p in sorted(scan_dir.glob("*.py")) if not p.name.startswith("_")
-        }
+        """Re-scan bundled + user plugin dirs, reload changed, remove deleted."""
+        current_files: Dict[str, Path] = {}
+        for scan_dir in (_BUNDLED_PLUGINS_DIR, _USER_PLUGINS_DIR):
+            if not scan_dir.is_dir():
+                continue
+            for p in sorted(scan_dir.glob("*.py")):
+                if p.name.startswith("_"):
+                    continue
+                current_files[str(p)] = p
 
         with self._lock:
             prev_mtime_map = dict(self._mtime_map)

--- a/server/services/plugin_manager.py
+++ b/server/services/plugin_manager.py
@@ -306,6 +306,8 @@ class PluginManager:
 
     def _hot_scan(self) -> None:
         """Re-scan bundled + user plugin dirs, reload changed, remove deleted."""
+        # Walk bundled first, user second — later entries override earlier
+        # ones when building the shadow map (user > bundled for same name).
         current_files: Dict[str, Path] = {}
         for scan_dir in (_BUNDLED_PLUGINS_DIR, _USER_PLUGINS_DIR):
             if not scan_dir.is_dir():
@@ -317,7 +319,6 @@ class PluginManager:
 
         with self._lock:
             prev_mtime_map = dict(self._mtime_map)
-            prev_path_to_name = dict(self._path_to_name)  # noqa: F841
 
         changed = False
 
@@ -337,8 +338,26 @@ class PluginManager:
                 continue
 
             name = instance.name
+            is_from_user_dir = str(p).startswith(str(_USER_PLUGINS_DIR))
             with self._lock:
                 old_entry = self._plugins.get(name)
+                # Shadow priority: a reloaded bundled file must NOT overwrite
+                # the active registry entry if that entry is backed by the
+                # user version. We still record new mtime so we don't re-import
+                # every scan.
+                if (
+                    old_entry is not None
+                    and not is_from_user_dir
+                    and str(Path(old_entry.filepath)).startswith(str(_USER_PLUGINS_DIR))
+                ):
+                    self._mtime_map[fpath] = mtime
+                    self._path_to_name[fpath] = name
+                    logger.info(
+                        "[PluginManager] Re-scanned bundled %s but user override is "
+                        "active — keeping user version",
+                        p.name,
+                    )
+                    continue
                 enabled = old_entry.enabled if old_entry else self._state.get(name, True)
                 entry = _PluginEntry(instance, fpath, mtime, enabled)
                 self._plugins[name] = entry
@@ -352,10 +371,55 @@ class PluginManager:
             with self._lock:
                 old_name = self._path_to_name.pop(fpath, None)
                 self._mtime_map.pop(fpath, None)
-                if old_name:
-                    self._plugins.pop(old_name, None)
-                    changed = True
-                    logger.info("[PluginManager] Removed plugin: %s", old_name)
+                if not old_name:
+                    continue
+                current_entry = self._plugins.get(old_name)
+                # Only drop from registry if the deleted file was THE active
+                # source for this plugin name. A deleted bundled file when the
+                # user version is active should be a silent delete.
+                if current_entry is None or current_entry.filepath != fpath:
+                    logger.info(
+                        "[PluginManager] Removed shadowed file %s (plugin %s still "
+                        "served by %s)",
+                        Path(fpath).name,
+                        old_name,
+                        current_entry.filepath if current_entry else "<none>",
+                    )
+                    continue
+
+                self._plugins.pop(old_name, None)
+                changed = True
+                logger.info("[PluginManager] Removed plugin: %s", old_name)
+
+                # Fall back to the bundled version if a user plugin was removed
+                # and a same-named bundled file exists (or vice versa — rare).
+                fallback_path = None
+                for alt_dir in (_USER_PLUGINS_DIR, _BUNDLED_PLUGINS_DIR):
+                    candidate = alt_dir / Path(fpath).name
+                    if str(candidate) != fpath and candidate.is_file():
+                        fallback_path = candidate
+                        break
+                if fallback_path is None:
+                    continue
+            # Load fallback OUTSIDE the lock (_load_plugin_from_file does I/O).
+            fallback_instance = self._load_plugin_from_file(fallback_path)
+            if fallback_instance is None:
+                continue
+            with self._lock:
+                try:
+                    fb_mtime = fallback_path.stat().st_mtime
+                except OSError:
+                    continue
+                enabled = self._state.get(fallback_instance.name, True)
+                fb_entry = _PluginEntry(fallback_instance, str(fallback_path), fb_mtime, enabled)
+                self._plugins[fallback_instance.name] = fb_entry
+                self._mtime_map[str(fallback_path)] = fb_mtime
+                self._path_to_name[str(fallback_path)] = fallback_instance.name
+                logger.info(
+                    "[PluginManager] Fell back to %s for plugin %s",
+                    fallback_path,
+                    fallback_instance.name,
+                )
 
         with self._lock:
             self._last_scan = time.monotonic()

--- a/server/tests/test_plugin_manager.py
+++ b/server/tests/test_plugin_manager.py
@@ -242,11 +242,12 @@ class TestReload:
         mgr.load_all(str(plugins_dir))
         assert len(mgr.list_plugins()) == 1
 
-        # Add a second plugin and reload. reload() calls load_all() which
-        # uses the default _PLUGINS_DIR, so monkeypatch it.
+        # Add a second plugin and reload. reload()/scan() iterate bundled +
+        # user dirs; redirect both to the tmp dir and move the state file.
         import server.services.plugin_manager as pm_mod
 
-        monkeypatch.setattr(pm_mod, "_PLUGINS_DIR", plugins_dir)
+        monkeypatch.setattr(pm_mod, "_BUNDLED_PLUGINS_DIR", plugins_dir)
+        monkeypatch.setattr(pm_mod, "_USER_PLUGINS_DIR", plugins_dir)
         monkeypatch.setattr(pm_mod, "_STATE_FILE", plugins_dir / "plugins_state.json")
 
         _write_plugin(plugins_dir, "first.py", _HIGH_PRIORITY_PLUGIN)
@@ -264,7 +265,8 @@ class TestReload:
 
         import server.services.plugin_manager as pm_mod
 
-        monkeypatch.setattr(pm_mod, "_PLUGINS_DIR", plugins_dir)
+        monkeypatch.setattr(pm_mod, "_BUNDLED_PLUGINS_DIR", plugins_dir)
+        monkeypatch.setattr(pm_mod, "_USER_PLUGINS_DIR", plugins_dir)
         monkeypatch.setattr(pm_mod, "_STATE_FILE", plugins_dir / "plugins_state.json")
 
         (plugins_dir / "hello.py").unlink()

--- a/server/user_plugins/.gitignore
+++ b/server/user_plugins/.gitignore
@@ -1,0 +1,5 @@
+# User-added plugins are per-install, not shipped. The directory itself is
+# tracked (via this .gitignore) so Docker bind-mounts + first-run scans work.
+*.py
+!.gitignore
+!README.md

--- a/server/user_plugins/README.md
+++ b/server/user_plugins/README.md
@@ -1,0 +1,11 @@
+# User Plugins
+
+Drop custom `DanmuPlugin` subclasses here as single `.py` files. They load
+alongside the bundled examples in `../plugins/` and share the same
+enabled/disabled state at `../runtime/plugins_state.json`.
+
+See `../plugins/example_*.py` for reference implementations and
+`../PLUGIN_GUIDE.md` for the full SDK.
+
+This directory is gitignored — put your plugins under version control
+separately if you want to track them.


### PR DESCRIPTION
## Summary

Completes the v4.6.2 deployment persistence fix by handling the two
remaining data-loss vectors: the `/tmp` default for settings, and the
plugin architecture that made plugin state impossible to persist without
shadowing bundled example plugins.

## What's fixed

### 🐛 `SETTINGS_FILE` default was `/tmp`
`tempfile.gettempdir()` → `/tmp` which macOS clears on reboot (and some
Linux configs). Non-Docker users running `uv run python -m server.app`
directly lost their color / opacity / speed / font settings every boot.
Docker users were already redirected via env var, but the default should
match. Now defaults to `server/runtime/settings.json`.

### 🐛 Plugin state persistence (v4.6.2 deferred item)
v4.6.2 removed the `./server/plugins` mount because it shadowed bundled
example plugins, leaving plugin state unpersisted. Fixed architecturally:

- **`server/plugins/`** — bundled examples, part of the image (read-only
  intent; upstream fixes arrive on upgrade).
- **`server/user_plugins/`** — user custom plugins; gitignored on host,
  bind-mounted in docker-compose.
- **`server/runtime/plugins_state.json`** — enabled/disabled toggles,
  persisted with the rest of runtime state.

`PluginManager` scans both dirs on `load_all()` / `_hot_scan()`. Plugin
name collision: user version wins.

**Legacy migration:** On first load, if `server/plugins/plugins_state.json`
exists and the new `runtime/` location doesn't, the state is copied
automatically. Users upgrading from v4.6.2 or earlier don't need to do
anything — their toggles come along.

### 🔧 `scripts/backup.sh`
One-command snapshot of `server/runtime/`, `server/user_plugins/`,
`server/user_fonts/`, `server/static/`, `.env` into a dated tarball.
Referenced from DEPLOYMENT.md.

## Test plan

- [x] `pytest` non-browser: **710 passed, 1 skipped**
- [x] Plugin-specific: **16 pass** (incl. updated TestReload which
      monkeypatches both new dir constants)
- [x] Webhook tests: **12 pass** (after restoring `import os` for
      atomic-save in settings.py that was accidentally removed)
- [x] Settings fallback test: `test_corrupt_settings_file_falls_back_to_defaults`
      passes with env monkeypatch working through runtime fallback
- [x] `black` / `flake8` / `isort` all green
- [x] `scripts/backup.sh /tmp/test.tgz` writes valid tarball (71 entries)

## Version

`danmu-desktop/package.json` + `server/config.py` → **4.6.3**.
Triggers `build.yml` on merge → GitHub Release v4.6.3 with 3 platform
binaries.

## Commits

1. `fix(storage)` — SETTINGS_FILE default /tmp → runtime/
2. `feat(plugins)` — split bundled vs user paths + backup.sh + docs +
   version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)