### PR TITLE
chore(v4.6.4): bump-version.sh + setup.sh gen-secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ server/webhooks.json
 # local MCP server config
 .mcp.json
 .worktrees/
+
+# Retro snapshots (local history, not shipped)
+.context/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@
 
 ---
 
+## [4.6.4] - 2026-04-20
+
+### 新增 / Added
+
+- **`scripts/bump-version.sh`**：一鍵同步更新 `danmu-desktop/package.json`、`server/config.py`、`CHANGELOG.md` 三處版本號。支援 `DRY_RUN=1` 預覽、版本格式驗證、自動 section 插入。
+- **`setup.sh gen-secret`**：新指令，在 `.env` 遺失 `SECRET_KEY` 時一鍵產生 256-bit hex key 並寫入。原本 `setup.sh check` 只會回報錯誤沒指示如何修，現在錯誤訊息直接提示修復指令。
+
+### 改善 / Improved
+
+- `setup.sh check` 偵測 production 無 `SECRET_KEY` 時，錯誤後附上 `./setup.sh gen-secret` 與 `./setup.sh init` 兩種修復路徑。
+
+---
+
 ## [4.6.3] - 2026-04-20
 
 ### 修復 / Fixed

--- a/danmu-desktop/package.json
+++ b/danmu-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danmu-desktop",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "description": "Danmu overlay controller for live streaming",
   "main": "dist/main.bundle.js",
   "scripts": {

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# bump-version.sh — atomic version bump across all canonical files.
+#
+# Keeps these in sync (they all have to match or build.yml + the UI show
+# different versions):
+#   danmu-desktop/package.json  — drives build.yml release trigger
+#   server/config.py             — injected into all templates via context_processor
+#   CHANGELOG.md                 — [Unreleased] header promoted to [<new>] - <date>
+#
+# Usage:
+#   ./scripts/bump-version.sh 4.6.4           # bump to 4.6.4, dated today
+#   ./scripts/bump-version.sh 4.7.0 2026-05-01 # bump to 4.7.0, dated given
+#   DRY_RUN=1 ./scripts/bump-version.sh 4.6.4 # preview without writing
+#
+# Version format: MAJOR.MINOR.PATCH (semver-ish). Four-part versions like
+# 4.6.1.2 are not supported.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+NEW="${1:-}"
+DATE="${2:-$(date +%F)}"
+DRY_RUN="${DRY_RUN:-0}"
+
+if [ -z "$NEW" ]; then
+  echo "Usage: $0 <new-version> [<date>]" >&2
+  echo "Example: $0 4.6.4" >&2
+  exit 1
+fi
+
+# Sanity: version matches N.N.N
+if ! [[ "$NEW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "ERROR: version must be MAJOR.MINOR.PATCH (got: $NEW)" >&2
+  exit 1
+fi
+
+# Read current version from the canonical source (package.json).
+CURRENT=$(grep -E '^\s*"version"' danmu-desktop/package.json | head -1 | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/')
+if [ -z "$CURRENT" ]; then
+  echo "ERROR: could not parse current version from danmu-desktop/package.json" >&2
+  exit 1
+fi
+
+echo "Bumping: $CURRENT → $NEW (date: $DATE)"
+
+# Check all three files are in sync before touching anything.
+CFG_VER=$(grep -E '^\s*APP_VERSION' server/config.py | head -1 | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/')
+if [ "$CFG_VER" != "$CURRENT" ]; then
+  echo "WARN: server/config.py APP_VERSION ($CFG_VER) doesn't match package.json ($CURRENT)." >&2
+  echo "      Continuing — bump will force both to $NEW." >&2
+fi
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "DRY RUN — would update:"
+  echo "  danmu-desktop/package.json: \"version\": \"$CURRENT\" → \"$NEW\""
+  echo "  server/config.py:           APP_VERSION = \"$CURRENT\" → \"$NEW\""
+  echo "  CHANGELOG.md:               add [### $NEW] - $DATE after [Unreleased]"
+  exit 0
+fi
+
+# 1. package.json
+sed -i.bak -E "s/\"version\": \"$CURRENT\"/\"version\": \"$NEW\"/" danmu-desktop/package.json
+rm -f danmu-desktop/package.json.bak
+
+# 2. server/config.py
+sed -i.bak -E "s/APP_VERSION = \"$CURRENT\"/APP_VERSION = \"$NEW\"/" server/config.py
+rm -f server/config.py.bak
+
+# 3. CHANGELOG.md — insert new section after [Unreleased] if not already there.
+if grep -qE "^## \[$NEW\]" CHANGELOG.md; then
+  echo "WARN: CHANGELOG.md already has [$NEW] section — skipping CHANGELOG edit."
+else
+  # Use awk to insert a new section right after [Unreleased] block.
+  # Finds the [Unreleased] heading, consumes any blank + --- separator lines,
+  # then inserts our new section header and a single --- separator.
+  awk -v ver="$NEW" -v date="$DATE" '
+    BEGIN { inserted = 0 }
+    /^## \[Unreleased\]/ && !inserted {
+      print
+      # Drain the blank-line and (possibly already present) --- separator
+      # that normally follow [Unreleased], so we do not insert a double.
+      while ((getline line) > 0) {
+        if (line ~ /^---$/) { break }          # existing separator, swallow
+        if (line ~ /^[[:space:]]*$/) { continue }
+        # First non-blank non-separator line — belongs to unreleased content,
+        # re-emit it AFTER our insertion.
+        saved = line
+        break
+      }
+      print ""
+      print "## [" ver "] - " date
+      print ""
+      print "<!-- fill in release notes -->"
+      print ""
+      print "---"
+      if (saved != "") { print ""; print saved; saved = "" }
+      inserted = 1
+      next
+    }
+    { print }
+  ' CHANGELOG.md > CHANGELOG.md.tmp
+  mv CHANGELOG.md.tmp CHANGELOG.md
+fi
+
+echo "Done."
+echo ""
+echo "Changed files:"
+git status --porcelain -- danmu-desktop/package.json server/config.py CHANGELOG.md
+echo ""
+echo "Next steps:"
+echo "  1. Fill in CHANGELOG.md [$NEW] section with actual release notes"
+echo "  2. git add danmu-desktop/package.json server/config.py CHANGELOG.md"
+echo "  3. git commit -m 'chore: bump version to $NEW'"

--- a/server/config.py
+++ b/server/config.py
@@ -39,7 +39,7 @@ class Config:
     # Priority: runtime hash file > ADMIN_PASSWORD_HASHED env var > plaintext ADMIN_PASSWORD
     ADMIN_PASSWORD_HASHED = load_runtime_hash() or os.getenv("ADMIN_PASSWORD_HASHED", "")
     APP_NAME = "Danmu Fire"
-    APP_VERSION = "4.6.3"
+    APP_VERSION = "4.6.4"
     PORT = int(os.getenv("PORT", "4000"))
     WS_PORT = int(os.getenv("WS_PORT", "4001"))
     ENV = os.getenv("ENV", "development").lower()

--- a/setup.sh
+++ b/setup.sh
@@ -48,6 +48,8 @@ _validate_env() {
   local env_val="${ENV:-production}"
   if [ "$env_val" = "production" ] && [ -z "${SECRET_KEY:-}" ]; then
     _error "SECRET_KEY must be set when ENV=production"
+    _info "  fix: ./setup.sh gen-secret  (generates and writes SECRET_KEY into .env)"
+    _info "  or:  ./setup.sh init        (full interactive wizard)"
     errors=$((errors+1))
   fi
 
@@ -391,14 +393,42 @@ _init() {
 
 # ── Entry point ───────────────────────────────────────────────────────────────
 
+_gen_secret() {
+  local env_file="${1:-.env}"
+  if [ ! -f "$env_file" ]; then
+    _error "$env_file not found. Run './setup.sh init' first or 'cp .env.example $env_file'."
+    exit 1
+  fi
+
+  local key
+  key=$(python3 -c 'import secrets; print(secrets.token_hex(32))' 2>/dev/null || openssl rand -hex 32)
+  if [ -z "$key" ]; then
+    _error "Neither python3 nor openssl available — cannot generate SECRET_KEY."
+    exit 1
+  fi
+
+  if grep -Eq "^[[:space:]]*#?[[:space:]]*SECRET_KEY=" "$env_file"; then
+    local esc
+    esc=$(printf '%s' "$key" | sed -e 's/[\/&|]/\\&/g')
+    sed -i.bak -E "s|^[[:space:]]*#?[[:space:]]*SECRET_KEY=.*|SECRET_KEY=${esc}|" "$env_file" && rm -f "${env_file}.bak"
+  else
+    printf 'SECRET_KEY=%s\n' "$key" >> "$env_file"
+  fi
+
+  _ok "Wrote SECRET_KEY into $env_file (${#key}-char hex, $((${#key} * 4)) bits)."
+  _info "Sessions and signed tokens now have a stable key across restarts."
+}
+
 case "${1:-}" in
-  init)  _init "${2:-}" ;;
-  check) _PROFILE="${2:-}" _validate_env "${3:-.env}" ;;
+  init)       _init "${2:-}" ;;
+  check)      _PROFILE="${2:-}" _validate_env "${3:-.env}" ;;
+  gen-secret) _gen_secret "${2:-.env}" ;;
   *)
     echo "Usage:"
     echo "  ./setup.sh init              Interactive wizard → writes .env"
     echo "  ./setup.sh init --advanced   Wizard + rate limit / log / resource prompts"
     echo "  ./setup.sh check [profile]   Validate existing .env"
+    echo "  ./setup.sh gen-secret [file] Generate & write SECRET_KEY into .env"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

Two small tools from the 24h retro's P0 / P2 list:

1. **`scripts/bump-version.sh`** — atomic version sync across the 3 canonical files.
   v4.6.0-v4.6.3 each touched them manually; this removes the drift risk.
2. **`setup.sh gen-secret`** — one-command SECRET_KEY fix when users hit the
   `setup.sh check` validation error without running the full wizard.

## Why

Every release so far, I've had to:
1. edit `danmu-desktop/package.json` version
2. edit `server/config.py` APP_VERSION
3. add a CHANGELOG.md section

Four releases in, that's 12 file edits that could have been one command.
`bump-version.sh 4.7.0` now does all three, and fails noisily if the files
are out of sync before the bump.

`setup.sh gen-secret` came from the retro audit: running `./setup.sh check`
on a fresh `.env.example` correctly flags missing SECRET_KEY in production
but then told users nothing about how to fix it. Copy-pasting `python3 -c
'import secrets...'` was the answer but nowhere in the CLI suggested it.

## Test plan

- [x] `DRY_RUN=1 ./scripts/bump-version.sh 4.6.5` shows the right diff
- [x] `./scripts/bump-version.sh 4.6.4` actually applied (this PR)
- [x] `./scripts/bump-version.sh not-a-version` rejects with clear error
- [x] `./scripts/bump-version.sh` with no arg shows usage
- [x] `./setup.sh gen-secret /tmp/test.env` writes a 64-char hex key
- [x] `./setup.sh gen-secret /tmp/does-not-exist.env` errors clearly
- [x] `./setup.sh check` now shows the `./setup.sh gen-secret` fix hint
- [x] `./setup.sh` usage lists all 4 subcommands (init / check / gen-secret / advanced)
- [x] 710 pytest green + black/flake8/isort clean

## Not included

- Version 4.6.4 bump is part of this PR (via the new script itself) but no
  behavioral change — this is a tooling-only release.
- No Electron / server logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `setup.sh gen-secret` command to automatically generate and configure the required encryption key when it's missing.

* **Bug Fixes**
  * Improved setup validation error messages to clearly guide users to repair commands (`gen-secret` and `init`).

* **Chores**
  * Version bumped to 4.6.4 across all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->