### PR TITLE
feat(v4.7.0): Stream mode toggle + runtime state consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@
 
 ## [Unreleased]
 
+## [4.7.0] - 2026-04-20
+
+### 新增 / Added
+
+- **直播模式 / Stream mode toggle**：Admin 頁 hero 右上新增 toggle 開關，開啟後自動折疊 11 個低頻率區段（Themes / Emojis / Stickers / Sounds / Polls / Plugins / Webhooks / Scheduler / Change password / Filters / Advanced），只保留直播中真的會用到的：Live Feed、黑名單、Effects、歷史、Core controls。Hero summary cards 同步縮小。偏好存 `localStorage['danmu-stream-mode']`，reload 後 before-paint 套用不閃爍。i18n 4 語系齊備（中：直播模式、日：配信モード、韓：방송 모드、英：Stream mode）。
+- **Legacy runtime-state migration**：`filter_engine.py` 與 `webhook.py` 新增 one-shot 自動搬家邏輯，從舊 default（`server/filter_rules.json`、`server/webhooks.json`）搬到新的 `server/runtime/` 位置。只在使用 default path 時觸發，不影響測試 monkeypatch。
+
+### 改善 / Improved
+
+- **`filter_rules.json` + `webhooks.json` 預設路徑對齊**：跟 v4.6.3 的 `SETTINGS_FILE` / `plugins_state.json` 一致，預設全部改到 `server/runtime/`，backup.sh 一個指令即可涵蓋整組 user state。
+- Docker 使用者無感（已經 bind-mount `./server/runtime/`）。非 Docker 直跑的使用者升級後會看到一次性 migration log，原檔保留不刪。
+
+---
+
 ## [4.6.5] - 2026-04-20
 
 ### 修復 / Fixed

--- a/danmu-desktop/package.json
+++ b/danmu-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danmu-desktop",
-  "version": "4.6.5",
+  "version": "4.7.0",
   "description": "Danmu overlay controller for live streaming",
   "main": "dist/main.bundle.js",
   "scripts": {

--- a/server/config.py
+++ b/server/config.py
@@ -39,7 +39,7 @@ class Config:
     # Priority: runtime hash file > ADMIN_PASSWORD_HASHED env var > plaintext ADMIN_PASSWORD
     ADMIN_PASSWORD_HASHED = load_runtime_hash() or os.getenv("ADMIN_PASSWORD_HASHED", "")
     APP_NAME = "Danmu Fire"
-    APP_VERSION = "4.6.5"
+    APP_VERSION = "4.7.0"
     PORT = int(os.getenv("PORT", "4000"))
     WS_PORT = int(os.getenv("WS_PORT", "4001"))
     ENV = os.getenv("ENV", "development").lower()
@@ -117,17 +117,20 @@ class Config:
     # Sticker configuration
     STICKER_MAX_COUNT = int(os.getenv("STICKER_MAX_COUNT", "50"))
 
-    # Filter engine configuration
-    # Reads FILTER_RULES_FILE to match what services/filter_engine.py actually uses.
+    # Filter engine configuration. Same runtime/ pattern as SETTINGS_FILE and
+    # WEBHOOKS_PATH — all user state consolidated in one backup-friendly dir.
+    # Migration: services/filter_engine.py checks the legacy location
+    # (server/filter_rules.json) and moves the file on first load.
     FILTER_RULES_FILE = os.getenv(
         "FILTER_RULES_FILE",
-        str(Path(__file__).parent / "filter_rules.json"),
+        str(Path(__file__).parent / "runtime" / "filter_rules.json"),
     )
 
-    # Webhook configuration
+    # Webhook configuration. Default is runtime/webhooks.json (consolidated
+    # state); webhook.py migrates legacy server/webhooks.json on first load.
     WEBHOOKS_PATH = os.getenv(
         "WEBHOOKS_PATH",
-        str(Path(__file__).parent / "webhooks.json"),
+        str(Path(__file__).parent / "runtime" / "webhooks.json"),
     )
     WEBHOOK_TIMEOUT = int(os.getenv("WEBHOOK_TIMEOUT", "10"))
 

--- a/server/services/filter_engine.py
+++ b/server/services/filter_engine.py
@@ -306,10 +306,41 @@ class FilterEngine:
     # ── Persistence ─────────────────────────────────────────────
 
     def _load(self) -> None:
-        """Load rules from the JSON file. Silently starts empty if file is missing or corrupt."""
+        """Load rules from the JSON file. Silently starts empty if file is missing or corrupt.
+
+        One-time migration: v4.7.0 moved the default to server/runtime/filter_rules.json.
+        Only migrates when self._path is the default (not a custom test path), so
+        test isolation isn't broken by leaking the legacy host file.
+        """
         if not os.path.isfile(self._path):
-            self._rules = []
-            return
+            try:
+                from server.config import Config as _Cfg
+
+                default_path = _Cfg.FILTER_RULES_FILE
+            except Exception:
+                default_path = None
+            if default_path and os.path.abspath(self._path) == os.path.abspath(default_path):
+                legacy = os.path.join(
+                    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                    "filter_rules.json",
+                )
+                if os.path.isfile(legacy) and os.path.abspath(legacy) != os.path.abspath(
+                    self._path
+                ):
+                    try:
+                        os.makedirs(os.path.dirname(self._path), exist_ok=True)
+                        import shutil
+
+                        shutil.copy2(legacy, self._path)
+                    except Exception:
+                        self._rules = []
+                        return
+                else:
+                    self._rules = []
+                    return
+            else:
+                self._rules = []
+                return
         try:
             with open(self._path, "r", encoding="utf-8") as f:
                 raw = json.load(f)

--- a/server/services/webhook.py
+++ b/server/services/webhook.py
@@ -138,8 +138,14 @@ class WebhookService:
                 and legacy.resolve() != _WEBHOOKS_FILE.resolve()
             ):
                 try:
+                    # shutil.copy2 preserves mtime + permissions. Matters here
+                    # because webhooks.json can contain secrets — we want to
+                    # carry over any restrictive chmod (e.g. 600) the operator
+                    # set, not fall back to umask defaults.
+                    import shutil
+
                     _WEBHOOKS_FILE.parent.mkdir(parents=True, exist_ok=True)
-                    _WEBHOOKS_FILE.write_bytes(legacy.read_bytes())
+                    shutil.copy2(legacy, _WEBHOOKS_FILE)
                     logger.info("Migrated legacy webhooks %s -> %s", legacy, _WEBHOOKS_FILE)
                 except Exception:
                     logger.exception("Failed to migrate legacy webhooks")

--- a/server/services/webhook.py
+++ b/server/services/webhook.py
@@ -122,9 +122,30 @@ class WebhookService:
     # ── Persistence ──────────────────────────────────────────────────────
 
     def _load(self) -> None:
-        """Load webhooks from JSON file (called once at init, under no lock)."""
+        """Load webhooks from JSON file (called once at init, under no lock).
+
+        Legacy migration: v4.7.0 moved default to server/runtime/webhooks.json.
+        Migration only runs when _WEBHOOKS_FILE is the current default
+        (Config.WEBHOOKS_PATH) — tests that monkeypatch _WEBHOOKS_FILE to a
+        tmp path stay isolated.
+        """
         if not _WEBHOOKS_FILE.exists():
-            return
+            default_is_current = str(_WEBHOOKS_FILE) == str(Config.WEBHOOKS_PATH)
+            legacy = Path(__file__).parent.parent / "webhooks.json"
+            if (
+                default_is_current
+                and legacy.is_file()
+                and legacy.resolve() != _WEBHOOKS_FILE.resolve()
+            ):
+                try:
+                    _WEBHOOKS_FILE.parent.mkdir(parents=True, exist_ok=True)
+                    _WEBHOOKS_FILE.write_bytes(legacy.read_bytes())
+                    logger.info("Migrated legacy webhooks %s -> %s", legacy, _WEBHOOKS_FILE)
+                except Exception:
+                    logger.exception("Failed to migrate legacy webhooks")
+                    return
+            else:
+                return
         try:
             raw = json.loads(_WEBHOOKS_FILE.read_text(encoding="utf-8"))
             for entry in raw:

--- a/server/static/css/style.css
+++ b/server/static/css/style.css
@@ -385,6 +385,91 @@ summary:focus-visible {
   }
 }
 
+/* ─── Stream mode toggle + hiding ──────────────────────────────────────────
+ * When body.stream-mode is set, low-frequency sections collapse so the
+ * streamer only sees the controls they touch mid-broadcast (live feed,
+ * blacklist, core controls, effects, history). Toggle persists to
+ * localStorage "danmu-stream-mode". Selector list intentionally narrow
+ * — new sections default to visible unless added here. */
+.stream-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  padding: 0.25rem 0.65rem 0.25rem 0.25rem;
+  border: 1px solid rgba(51, 65, 85, 0.72);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.62);
+  transition: border-color 0.2s, background-color 0.2s, color 0.2s;
+}
+.stream-mode-toggle:hover {
+  border-color: rgba(56, 189, 248, 0.45);
+  color: var(--color-text-primary);
+}
+.stream-mode-toggle input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+.stream-mode-track {
+  position: relative;
+  display: inline-block;
+  width: 32px;
+  height: 18px;
+  background: rgba(71, 85, 105, 0.8);
+  border-radius: 999px;
+  transition: background-color 0.2s;
+}
+.stream-mode-track::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+.stream-mode-toggle input:checked + .stream-mode-track {
+  background: var(--color-primary);
+}
+.stream-mode-toggle input:checked + .stream-mode-track::after {
+  transform: translateX(14px);
+}
+.stream-mode-toggle input:focus-visible + .stream-mode-track {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* Hide low-frequency sections when stream mode is on.
+ * Keep high-freq visible: live-feed, blacklist, effects, history,
+ * moderation core controls (sec-moderation), and the chip quick-nav. */
+body.stream-mode #sec-themes,
+body.stream-mode #sec-emojis,
+body.stream-mode #sec-stickers,
+body.stream-mode #sec-sounds,
+body.stream-mode #sec-polls,
+body.stream-mode #sec-plugins,
+body.stream-mode #sec-webhooks,
+body.stream-mode #sec-scheduler,
+body.stream-mode #sec-security,
+body.stream-mode #sec-filters,
+body.stream-mode #sec-advanced {
+  display: none;
+}
+
+/* Slim the hero while streaming — less ornament, more signal */
+body.stream-mode .admin-hero {
+  padding: 1rem 1.25rem;
+}
+body.stream-mode .admin-hero .admin-summary-grid {
+  display: none;
+}
+
 @media (max-width: 640px) {
   .admin-summary-grid {
     grid-template-columns: 1fr;

--- a/server/static/js/admin.js
+++ b/server/static/js/admin.js
@@ -2,6 +2,16 @@ document.addEventListener("DOMContentLoaded", () => {
   const csrfToken =
     document.querySelector('meta[name="csrf-token"]').content || "";
 
+  // Apply persisted stream-mode class immediately (before render) to avoid
+  // flash of low-freq sections on reload.
+  try {
+    if (localStorage.getItem("danmu-stream-mode") === "1") {
+      document.body.classList.add("stream-mode");
+    }
+  } catch (e) {
+    /* localStorage blocked — that is ok, session only */
+  }
+
   // --- VANTA.js Background Initialization ---
   try {
     VANTA.NET({
@@ -752,6 +762,11 @@ document.addEventListener("DOMContentLoaded", () => {
                                         </p>
                                     </div>
                                     <div class="flex items-center gap-2 w-full lg:w-auto">
+                                        <label class="stream-mode-toggle" title="${ServerI18n.t("streamModeHelp")}">
+                                          <input type="checkbox" id="streamModeToggle" ${localStorage.getItem("danmu-stream-mode") === "1" ? "checked" : ""} />
+                                          <span class="stream-mode-track" aria-hidden="true"></span>
+                                          <span class="stream-mode-label" data-i18n="streamMode">${ServerI18n.t("streamMode")}</span>
+                                        </label>
                                         <select id="server-lang-select"
                                           class="bg-slate-800/60 border border-slate-700 text-slate-300 text-xs rounded-lg px-2 py-2 focus:ring-sky-400 focus:border-sky-400">
                                           <option value="en" ${ServerI18n.currentLang === "en" ? "selected" : ""}>EN</option>
@@ -1349,6 +1364,22 @@ document.addEventListener("DOMContentLoaded", () => {
   function addEventListeners() {
     if (window.ServerI18n && typeof window.ServerI18n.bindLanguageSelector === "function") {
       window.ServerI18n.bindLanguageSelector();
+    }
+
+    // Stream mode toggle — hide low-frequency sections during live streaming.
+    // Preference persisted in localStorage so it survives reloads.
+    const streamToggle = document.getElementById("streamModeToggle");
+    if (streamToggle) {
+      // Apply initial state (set by DOMContentLoaded handler too, but safe to re-apply)
+      document.body.classList.toggle("stream-mode", streamToggle.checked);
+      streamToggle.addEventListener("change", function () {
+        document.body.classList.toggle("stream-mode", this.checked);
+        try {
+          localStorage.setItem("danmu-stream-mode", this.checked ? "1" : "0");
+        } catch (e) {
+          /* localStorage can fail in private mode — toggle still works session-local */
+        }
+      });
     }
 
     // Logout Button

--- a/server/static/js/admin.js
+++ b/server/static/js/admin.js
@@ -763,7 +763,7 @@ document.addEventListener("DOMContentLoaded", () => {
                                     </div>
                                     <div class="flex items-center gap-2 w-full lg:w-auto">
                                         <label class="stream-mode-toggle" title="${ServerI18n.t("streamModeHelp")}">
-                                          <input type="checkbox" id="streamModeToggle" ${localStorage.getItem("danmu-stream-mode") === "1" ? "checked" : ""} />
+                                          <input type="checkbox" id="streamModeToggle" ${document.body.classList.contains("stream-mode") ? "checked" : ""} />
                                           <span class="stream-mode-track" aria-hidden="true"></span>
                                           <span class="stream-mode-label" data-i18n="streamMode">${ServerI18n.t("streamMode")}</span>
                                         </label>

--- a/server/static/js/i18n.js
+++ b/server/static/js/i18n.js
@@ -494,7 +494,9 @@
       "widgetTickerPlaceholder": "Enter messages, one per line...",
       "widgetLabelText": "Text",
       "exportJSON": "Export JSON",
-      "recordReplay": "Record Replay"
+      "recordReplay": "Record Replay",
+      "streamMode": "Stream mode",
+      "streamModeHelp": "Hide low-frequency sections while live (themes, sounds, plugins, etc.) Preference saved locally."
     },
     "zh": {
       "mainTitle": "Danmu Fire",
@@ -981,7 +983,9 @@
       "widgetTickerPlaceholder": "輸入訊息，每行一則...",
       "widgetLabelText": "文字",
       "exportJSON": "匯出 JSON",
-      "recordReplay": "錄製回放"
+      "recordReplay": "錄製回放",
+      "streamMode": "直播模式",
+      "streamModeHelp": "直播中隱藏低頻率區段（佈景、音效、插件等）。偏好會記在本機。"
     },
     "ja": {
       "mainTitle": "Danmu Fire",
@@ -1468,7 +1472,9 @@
       "widgetTickerPlaceholder": "メッセージを入力、1行に1つ...",
       "widgetLabelText": "テキスト",
       "exportJSON": "JSONエクスポート",
-      "recordReplay": "リプレイ録画"
+      "recordReplay": "リプレイ録画",
+      "streamMode": "配信モード",
+      "streamModeHelp": "配信中は低頻度のセクション（テーマ、サウンド、プラグインなど）を隠します。設定はローカルに保存されます。"
     },
     "ko": {
       "mainTitle": "Danmu Fire",
@@ -1955,7 +1961,9 @@
       "widgetTickerPlaceholder": "메시지 입력, 줄당 하나...",
       "widgetLabelText": "텍스트",
       "exportJSON": "JSON 내보내기",
-      "recordReplay": "리플레이 녹화"
+      "recordReplay": "리플레이 녹화",
+      "streamMode": "방송 모드",
+      "streamModeHelp": "방송 중에는 사용 빈도가 낮은 섹션(테마, 사운드, 플러그인 등)을 숨깁니다. 설정은 로컬에 저장됩니다."
     }
   };
 

--- a/server/static/locales/en/translation.json
+++ b/server/static/locales/en/translation.json
@@ -483,5 +483,7 @@
   "widgetTickerPlaceholder": "Enter messages, one per line...",
   "widgetLabelText": "Text",
   "exportJSON": "Export JSON",
-  "recordReplay": "Record Replay"
+  "recordReplay": "Record Replay",
+  "streamMode": "Stream mode",
+  "streamModeHelp": "Hide low-frequency sections while live (themes, sounds, plugins, etc.) Preference saved locally."
 }

--- a/server/static/locales/ja/translation.json
+++ b/server/static/locales/ja/translation.json
@@ -483,5 +483,7 @@
   "widgetTickerPlaceholder": "メッセージを入力、1行に1つ...",
   "widgetLabelText": "テキスト",
   "exportJSON": "JSONエクスポート",
-  "recordReplay": "リプレイ録画"
+  "recordReplay": "リプレイ録画",
+  "streamMode": "配信モード",
+  "streamModeHelp": "配信中は低頻度のセクション（テーマ、サウンド、プラグインなど）を隠します。設定はローカルに保存されます。"
 }

--- a/server/static/locales/ko/translation.json
+++ b/server/static/locales/ko/translation.json
@@ -483,5 +483,7 @@
   "widgetTickerPlaceholder": "메시지 입력, 줄당 하나...",
   "widgetLabelText": "텍스트",
   "exportJSON": "JSON 내보내기",
-  "recordReplay": "리플레이 녹화"
+  "recordReplay": "리플레이 녹화",
+  "streamMode": "방송 모드",
+  "streamModeHelp": "방송 중에는 사용 빈도가 낮은 섹션(테마, 사운드, 플러그인 등)을 숨깁니다. 설정은 로컬에 저장됩니다."
 }

--- a/server/static/locales/zh/translation.json
+++ b/server/static/locales/zh/translation.json
@@ -483,5 +483,7 @@
   "widgetTickerPlaceholder": "輸入訊息，每行一則...",
   "widgetLabelText": "文字",
   "exportJSON": "匯出 JSON",
-  "recordReplay": "錄製回放"
+  "recordReplay": "錄製回放",
+  "streamMode": "直播模式",
+  "streamModeHelp": "直播中隱藏低頻率區段（佈景、音效、插件等）。偏好會記在本機。"
 }


### PR DESCRIPTION
## Summary

v4.7.0 ships the P1 item from the 24h retro: a "Stream mode" toggle that
collapses low-frequency admin sections mid-broadcast, so streamers see
only the controls they actually touch while live.

Also consolidates `filter_rules.json` and `webhooks.json` default paths
into `server/runtime/` to finish the persistence-consolidation effort
started in v4.6.2/v4.6.3.

## Stream mode

**Problem (from retro):** During-live workflow needs ~4 controls (Live
Feed, Blacklist quick-add, Effects toggle, History preview). Before v4.7
the admin dashboard showed all 15+ sections in the same place as admin
chores (plugin config, webhook setup, theme packs). Streamers had to
scroll a 3,900px page to find the thing they needed in <1s.

**Fix:**
- Toggle in admin hero (top-right), next to language + logout.
- 4-language i18n: 直播模式 / 配信モード / 방송 모드 / Stream mode.
- `body.stream-mode` class hides 11 low-freq sections:
  themes / emojis / stickers / sounds / polls / plugins / webhooks /
  scheduler / change password / filters / advanced.
  Plus hero summary cards for more focus.
- High-freq stays visible: Live Feed, Blacklist, Effects, History,
  Core controls.
- `localStorage["danmu-stream-mode"]` persists the choice.
- `DOMContentLoaded` applies the class BEFORE admin panel renders, so
  no flash of low-freq sections on reload.

**Not implemented (future):** toggle collapses on mobile, sticky toggle
button, section-level per-user customization. Narrow scope for v4.7.0.

## Runtime paths

Caps the persistence refactor started in v4.6.2. Now all user state
defaults land under `server/runtime/`:

| File | v4.6.2-v4.6.5 default | v4.7.0 default |
|---|---|---|
| settings.json | runtime/ ✓ (since v4.6.3) | runtime/ |
| plugins_state.json | runtime/ ✓ (since v4.6.3) | runtime/ |
| filter_rules.json | `server/` | **`server/runtime/`** |
| webhooks.json | `server/` | **`server/runtime/`** |

`filter_engine.py` and `webhook.py` auto-migrate legacy files on first
load (same pattern as plugin state in v4.6.3). Migration only fires when
using the default path so test monkeypatching stays isolated.

## Test plan

- [x] `pytest`: 710 passed
- [x] `black` / `flake8` / `isort` clean
- [x] Preview MCP e2e verified:
  - [x] Toggle renders in 4 languages
  - [x] Toggle ON: 11/11 low-freq hidden, 4/4 high-freq visible
  - [x] localStorage stores "1" correctly
  - [x] Reload with stored="1" re-renders toggle checked + body.stream-mode applied pre-paint
- [x] `test_persistence_across_instances` green with new migration logic
  (proves migration is scoped to default path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)