### PR TITLE
fix(v4.8.2): deployment papercuts (Oracle Cloud UID + .env + graceful degradation)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,11 @@ ENV=production              # "production" enables secure defaults
 
 # === Security ===
 
-SECRET_KEY=                 # Required in production; empty is only acceptable for local/dev auto-generation
+# Required in production; empty is only acceptable for local/dev auto-generation.
+# DO NOT add an inline comment here — python-dotenv parses inline comments on
+# empty values as literal values, so `SECRET_KEY=  # hi` loads as "# hi",
+# defeating the security check.
+SECRET_KEY=
 
 # Session cookies
 # SESSION_COOKIE_SECURE must stay true in production; setting it false will refuse startup
@@ -51,7 +55,11 @@ CORS_ORIGINS=*              # Comma-separated origins; "*" = allow all
 # WebSocket authentication (dedicated WS server on port 4001)
 WS_HOST=0.0.0.0             # Bind address for dedicated WS server; 0.0.0.0 accepts all interfaces (same as HTTP server default)
 WS_REQUIRE_TOKEN=false      # Default is false; reachable clients can connect without a token, so keep port 4001 on trusted networks or enable WS_REQUIRE_TOKEN=true
-WS_AUTH_TOKEN=              # Shared secret; if WS_REQUIRE_TOKEN=true and this is empty, ALL clients rejected
+# Shared secret; if WS_REQUIRE_TOKEN=true and this is empty, ALL clients rejected.
+# Since v4.8.0 the admin UI is authoritative after first boot — this env is
+# only read as a seed when server/runtime/ws_auth.json does not exist yet.
+# DO NOT add an inline comment on this line (see SECRET_KEY note above).
+WS_AUTH_TOKEN=
 # Comma-separated origin list; leave blank (no trailing inline comment) for no restriction.
 # python-dotenv parses inline comments on empty values as literal values, which would
 # break WS auth. Keep these declarations value-only on their own lines.

--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,11 @@ ADMIN_PASSWORD=your_secure_password_here
 
 PORT=4000                   # HTTP server port
 WS_PORT=4001                # WebSocket server port
-ENV=production              # "production" enables secure defaults
+# "production" enables secure defaults (strict SECRET_KEY check, HSTS, etc).
+# `.env.example` ships as `development` so `cp .env.example .env` in CI and
+# local dev is a safe, boot-able starting point. `./setup.sh init` sets this
+# to `production` when configuring a real deploy.
+ENV=development
 
 # HTTPS / Traefik only:
 # HTTP_PORT=80

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@
 
 ## [Unreleased]
 
+## [4.8.2] - 2026-04-20
+
+Deployment-papercut release — all four fixes were triggered by an actual
+live deploy to Oracle Cloud where UID mismatch + .env inline-comment +
+cloud firewall combined to hide the problem behind cryptic log lines.
+
+### 修復 / Fixed
+
+- **`.env.example` inline-comment 被 python-dotenv 吞成值 (CRITICAL)**：
+  `SECRET_KEY=` 和 `WS_AUTH_TOKEN=` 兩行後面接了 `# comment`。dotenv 對
+  **空值 + inline `#` comment** 的處理是把整個 comment 當成值，所以
+  `WS_AUTH_TOKEN=              # Shared secret; ...` 會被 load 成
+  `"# Shared secret; ..."`，接著 admin UI 也會顯示這串 garbage 當 token。
+  修法：把說明註解移到變數的**上一行**，變數行保持 `KEY=`（值為空）。
+  同個 bug 之前在 `WS_ALLOWED_ORIGINS` 被修過，這次補齊剩下兩個受害者。
+- **`setup.sh` UID mismatch 無感知 (Oracle Cloud 常見)**：host 使用者 UID
+  ≠ 1000（Oracle / 某些 minimal image 的 `ubuntu` 是 1001）時，docker
+  bind-mount `server/runtime/` 會讓 container 的 `appuser`(uid 1000) 無法
+  寫入，ws_auth.json / settings.json / webhooks.json 等全部寫失敗但無
+  明顯錯誤訊息。`setup.sh init` 現在會：
+  - `mkdir -p server/runtime server/user_plugins`（避免 docker 用 root 預設建）
+  - 偵測 `$(id -u)` ≠ 1000 時 warn 並印出修復指令
+    `sudo chown -R 1000:1000 server/runtime server/user_plugins`
+- **`ws_auth.py` 寫入失敗時 log spam → 優雅降級**：先前每次 `set_state`
+  / 每次 boot 都會 `ERROR ... Permission denied`。現改為：
+  - 第一次失敗記一條 `WARNING` 附可行修復指令
+  - 後續失敗降到 `DEBUG`
+  - **in-memory cache 照更新** — admin UI 的變動在 container lifetime 內
+    仍生效（只是無法跨 restart），比先前「靜默丟失」好
+
+### 新增 / Added
+
+- **`DEPLOYMENT.md` 疑難排解新段**：
+  - `Permission denied writing runtime/ws_auth.json` — 完整診斷 + chown 修復
+  - `Cloud firewall blocking 4000 / 4001` — host iptables + cloud ingress 雙層
+    說明（Oracle Cloud / AWS / GCP 通則）
+
+### 技術細節 / Technical
+
+- **Tests**：`tests/test_ws_auth.py` 新增 4 個 graceful-degradation 測試
+  （seed 失敗 / set_state 失敗 / 一次性 log / rotate 失敗時 in-memory 可用）。
+  使用 `monkeypatch` 把 `os.open` 對 `ws_auth.tmp.*` 強制丟 `PermissionError`，
+  模擬 UID mismatch 情境不需真的改 host 權限。全部標 `@ws_auth_raw_seed`
+  opt out 預設的 disabled-state fixture。737 tests pass（v4.8.1: 733 + 4 new）。
+- **Build tooling**：`server/package.json` `build:css` script 在 tailwindcss
+  output 後追加 `\n`，避免 pre-commit `end-of-file-fixer` 每次重 build 都
+  strip 掉尾行 newline（v4.8.0、v4.8.1 都撞過這個 DX papercut）。
+
+---
+
 ## [4.8.1] - 2026-04-20
 
 ### 修復 / Fixed

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -348,11 +348,11 @@ overrides the image ownership and the container can't write. Common on
 Oracle Cloud images where the default human user is UID `1001`, not `1000`.
 
 Symptom: log lines like
-```
+```text
 ERROR | ... | Failed to write /app/server/runtime/ws_auth.json: [Errno 13] Permission denied
 ```
 or (v4.8.2+)
-```
+```text
 WARNING | ... | Cannot persist ... State will live in memory for this process only
 ```
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -339,3 +339,50 @@ Add `nginx/certs/fullchain.pem` to your browser or OS trust store.
 ```bash
 docker compose logs server
 ```
+
+**`Permission denied` writing `runtime/ws_auth.json` (or other runtime files)**
+
+The container runs as UID `1000` (`appuser`). If the host's `server/runtime/`
+or `server/user_plugins/` is owned by a different UID, the bind-mounted dir
+overrides the image ownership and the container can't write. Common on
+Oracle Cloud images where the default human user is UID `1001`, not `1000`.
+
+Symptom: log lines like
+```
+ERROR | ... | Failed to write /app/server/runtime/ws_auth.json: [Errno 13] Permission denied
+```
+or (v4.8.2+)
+```
+WARNING | ... | Cannot persist ... State will live in memory for this process only
+```
+
+Fix (run on host, from the repo root):
+```bash
+sudo chown -R 1000:1000 server/runtime server/user_plugins
+docker compose -f docker-compose.yml -f docker-compose.desktop.yml \
+  --profile https up -d --force-recreate server
+```
+
+v4.8.2+ `setup.sh init` detects this at install time and prints the chown
+command when `id -u` ≠ 1000.
+
+**Cloud firewall blocking 4000 / 4001 (Oracle Cloud / AWS / GCP)**
+
+Host-level `iptables` usually allows only 22/80/443 by default on cloud
+images; docker publishing a port opens the host socket but NOT the cloud
+ingress. Both must allow inbound.
+
+- **Host iptables** (Ubuntu/Oracle images):
+  ```bash
+  sudo iptables -I INPUT 10 -p tcp --dport 4000 -j ACCEPT
+  sudo iptables -I INPUT 10 -p tcp --dport 4001 -j ACCEPT
+  sudo netfilter-persistent save
+  ```
+- **Cloud security list / NSG**: add TCP ingress 4000 + 4001 from `0.0.0.0/0`
+  via your cloud provider's console, CLI, or terraform.
+  - OCI example (one-shot, run in Cloud Shell):
+    see wiki → Installation → "Oracle Cloud: open ports via CLI"
+
+Symptom: external `curl https://YOUR_IP:4000/health` times out (not refused).
+If iptables is the cause, `curl` from the same host via `127.0.0.1:4000`
+works. If cloud ingress is the cause, even a `dev laptop → VPS` test fails.

--- a/danmu-desktop/package.json
+++ b/danmu-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danmu-desktop",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "description": "Danmu overlay controller for live streaming",
   "main": "dist/main.bundle.js",
   "scripts": {

--- a/server/config.py
+++ b/server/config.py
@@ -39,7 +39,7 @@ class Config:
     # Priority: runtime hash file > ADMIN_PASSWORD_HASHED env var > plaintext ADMIN_PASSWORD
     ADMIN_PASSWORD_HASHED = load_runtime_hash() or os.getenv("ADMIN_PASSWORD_HASHED", "")
     APP_NAME = "Danmu Fire"
-    APP_VERSION = "4.8.1"
+    APP_VERSION = "4.8.2"
     PORT = int(os.getenv("PORT", "4000"))
     WS_PORT = int(os.getenv("WS_PORT", "4001"))
     ENV = os.getenv("ENV", "development").lower()

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "build:css": "tailwindcss -i tailwind.input.css -o static/css/tailwind.css --minify",
+    "build:css": "tailwindcss -i tailwind.input.css -o static/css/tailwind.css --minify && printf '\\n' >> static/css/tailwind.css",
     "watch:css": "tailwindcss -i tailwind.input.css -o static/css/tailwind.css --watch",
     "build:i18n": "node scripts/build-i18n.js",
     "build": "npm run build:i18n && npm run build:css"

--- a/server/services/ws_auth.py
+++ b/server/services/ws_auth.py
@@ -45,6 +45,12 @@ logger = logging.getLogger(__name__)
 _STATE_FILE = Path(__file__).parent.parent / "runtime" / "ws_auth.json"
 _lock = threading.RLock()
 _state: Optional[Dict] = None  # cached in-memory snapshot; load on first read
+# When the bind-mounted runtime/ dir is owned by the wrong UID (e.g. Oracle
+# Cloud images where `ubuntu` is UID 1001 but the container's `appuser` is
+# 1000), every write fails. Log the actionable remediation ONCE so we don't
+# spam ERROR on every connection — the service continues with in-memory
+# state, admin UI still works, changes just don't survive restart.
+_write_failure_logged: bool = False
 
 
 def _write_state(state: Dict) -> None:
@@ -120,6 +126,30 @@ def _seed_from_env() -> Dict:
     return {"require_token": require, "token": token}
 
 
+def _log_write_failure_once(exc: Exception) -> None:
+    """Emit a single actionable warning when the runtime file is unwritable.
+
+    Repeat failures go to DEBUG to avoid log spam — the service is
+    explicitly degrading to in-memory-only mode, not crashing.
+    """
+    global _write_failure_logged
+    if _write_failure_logged:
+        logger.debug("ws_auth persist still failing: %s", exc)
+        return
+    _write_failure_logged = True
+    logger.warning(
+        "Cannot persist %s (%s: %s). State will live in memory for this "
+        "process only — admin changes won't survive a container restart. "
+        "Common cause: host bind-mount owned by a different UID than the "
+        "container's `appuser` (1000). Fix: `sudo chown -R 1000:1000 "
+        "server/runtime server/user_plugins` on the host, then recreate "
+        "the container.",
+        _STATE_FILE,
+        type(exc).__name__,
+        exc,
+    )
+
+
 def _load() -> Dict:
     """Read runtime file, or seed + write if missing. Caller must hold _lock."""
     if _STATE_FILE.exists():
@@ -136,11 +166,15 @@ def _load() -> Dict:
             logger.warning("Failed to read %s: %s; re-seeding from env", _STATE_FILE, exc)
 
     seeded = _seed_from_env()
+    # Seeding write is "nice to have" — if the host bind mount is unwritable,
+    # we log once and keep going with in-memory state.
     try:
         _write_state(seeded)
         logger.info("Seeded ws_auth.json (require_token=%s)", seeded["require_token"])
-    except Exception as exc:
-        logger.error("Failed to write %s: %s", _STATE_FILE, exc)
+    except PermissionError as exc:
+        _log_write_failure_once(exc)
+    except OSError as exc:
+        _log_write_failure_once(exc)
     return seeded
 
 
@@ -164,6 +198,12 @@ def set_state(*, require_token: bool, token: str) -> Dict:
     Raises ValueError if require_token=True but token is empty — the admin
     schema should catch this, but we double-check at the persistence
     boundary so no bad state ever lands on disk.
+
+    Disk write failures (PermissionError / OSError on a misconfigured host
+    bind mount) are logged once and swallowed — the in-memory cache is
+    always updated so admin UI changes take effect immediately for this
+    process lifetime. They just won't survive a restart until the host dir
+    ownership is fixed.
     """
     require_token = bool(require_token)
     token = str(token or "")
@@ -172,8 +212,14 @@ def set_state(*, require_token: bool, token: str) -> Dict:
     global _state
     with _lock:
         new_state = {"require_token": require_token, "token": token}
-        _write_state(new_state)
+        # Update memory first so the change takes effect even if disk fails.
         _state = dict(new_state)
+        try:
+            _write_state(new_state)
+        except PermissionError as exc:
+            _log_write_failure_once(exc)
+        except OSError as exc:
+            _log_write_failure_once(exc)
         return dict(_state)
 
 
@@ -196,6 +242,7 @@ def _reset_for_tests() -> None:
     """Drop the in-memory cache. Tests should monkeypatch _STATE_FILE before
     calling get_state() so they don't pollute the real runtime file.
     """
-    global _state
+    global _state, _write_failure_logged
     with _lock:
         _state = None
+        _write_failure_logged = False

--- a/server/services/ws_auth.py
+++ b/server/services/ws_auth.py
@@ -167,12 +167,11 @@ def _load() -> Dict:
 
     seeded = _seed_from_env()
     # Seeding write is "nice to have" — if the host bind mount is unwritable,
-    # we log once and keep going with in-memory state.
+    # we log once and keep going with in-memory state. `PermissionError` is
+    # a subclass of `OSError`, so one handler covers both.
     try:
         _write_state(seeded)
         logger.info("Seeded ws_auth.json (require_token=%s)", seeded["require_token"])
-    except PermissionError as exc:
-        _log_write_failure_once(exc)
     except OSError as exc:
         _log_write_failure_once(exc)
     return seeded
@@ -216,9 +215,8 @@ def set_state(*, require_token: bool, token: str) -> Dict:
         _state = dict(new_state)
         try:
             _write_state(new_state)
-        except PermissionError as exc:
-            _log_write_failure_once(exc)
         except OSError as exc:
+            # PermissionError subclasses OSError — one handler covers both.
             _log_write_failure_once(exc)
         return dict(_state)
 

--- a/server/static/css/style.css
+++ b/server/static/css/style.css
@@ -952,7 +952,11 @@ body.stream-mode .admin-hero .admin-summary-grid {
   z-index: 1;
   width: min(100%, 22rem);
   background: rgb(14 165 233);
-  box-shadow: 0 16px 32px rgba(14, 165, 233, 0.24);
+  /* Shadow sized to fit within .composer-bar's `overflow: hidden` clip +
+   * 16px padding — prior `0 16px 32px` extended ~48px below the button
+   * and got chopped at the parent edge, looking like the bottom-right
+   * corner was visually "covered" by the card frame. */
+  box-shadow: 0 3px 10px rgba(14, 165, 233, 0.34);
   transition:
     padding 0.2s ease,
     font-size 0.2s ease,
@@ -963,7 +967,7 @@ body.stream-mode .admin-hero .admin-summary-grid {
 
 .composer-send:hover {
   background: rgb(56 189 248);
-  box-shadow: 0 20px 38px rgba(56, 189, 248, 0.28);
+  box-shadow: 0 5px 12px rgba(56, 189, 248, 0.4);
 }
 
 .server-settings-panel {

--- a/server/tests/test_ws_auth.py
+++ b/server/tests/test_ws_auth.py
@@ -8,6 +8,7 @@ clean and nothing leaks to the real runtime/ws_auth.json.
 """
 
 import json
+import os
 
 import pytest
 
@@ -309,3 +310,95 @@ def test_write_state_chmod_600(tmp_path):
     ws_auth.set_state(require_token=True, token="sensitive-token-here")
     mode = stat.S_IMODE(ws_auth._STATE_FILE.stat().st_mode)
     assert mode == 0o600, f"Expected 0o600, got 0o{mode:o}"
+
+
+# ── 6. Graceful degradation when the runtime dir is unwritable ──────────
+# Simulates the Oracle Cloud UID-mismatch case: host bind-mount owner is
+# a different UID than the container's appuser. Before v4.8.2, every
+# get_state / set_state raised or logged ERROR; admin UI silently lost
+# changes. After: in-memory state is authoritative, one-shot warning.
+
+
+def _force_permission_error(monkeypatch):
+    """Patch os.open to always raise PermissionError for the ws_auth tmp file."""
+    real_open = os.open
+    tmp_prefix = str(ws_auth._STATE_FILE.with_suffix("")) + ".tmp."
+
+    def guarded(path, *args, **kwargs):
+        if str(path).startswith(tmp_prefix):
+            raise PermissionError(13, "Permission denied", str(path))
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, "open", guarded)
+
+
+@pytest.mark.ws_auth_raw_seed
+def test_seed_survives_unwritable_runtime(monkeypatch, caplog):
+    """Boot-seed write fails → in-memory state is still usable."""
+    import logging
+
+    _force_permission_error(monkeypatch)
+    ws_auth._reset_for_tests()
+    with caplog.at_level(logging.WARNING, logger="server.services.ws_auth"):
+        state = ws_auth.get_state()
+    # Service still returns a valid state
+    assert "require_token" in state and "token" in state
+    # File was NOT written
+    assert not ws_auth._STATE_FILE.exists()
+    # One-shot warning logged with actionable guidance
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any("in memory" in r.getMessage() for r in warnings)
+    assert any("chown" in r.getMessage() for r in warnings)
+
+
+@pytest.mark.ws_auth_raw_seed
+def test_set_state_memory_only_mode(monkeypatch, caplog):
+    """Admin save with unwritable disk → change still takes effect in memory."""
+    import logging
+
+    _force_permission_error(monkeypatch)
+    ws_auth._reset_for_tests()
+    with caplog.at_level(logging.WARNING, logger="server.services.ws_auth"):
+        result = ws_auth.set_state(require_token=True, token="admin-set-tokenXYZ")
+    # Admin's change visible in the return value
+    assert result["require_token"] is True
+    assert result["token"] == "admin-set-tokenXYZ"
+    # And in subsequent get_state calls (cached in memory)
+    assert ws_auth.get_state()["token"] == "admin-set-tokenXYZ"
+    # File does not exist on disk
+    assert not ws_auth._STATE_FILE.exists()
+
+
+@pytest.mark.ws_auth_raw_seed
+def test_write_failure_logged_once(monkeypatch, caplog):
+    """Five failing writes produce a single WARNING, not five ERRORs."""
+    import logging
+
+    _force_permission_error(monkeypatch)
+    ws_auth._reset_for_tests()
+    with caplog.at_level(logging.DEBUG, logger="server.services.ws_auth"):
+        ws_auth.get_state()
+        for _ in range(4):
+            ws_auth.set_state(require_token=False, token="")
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    # Exactly one persistence-failure warning (first occurrence)
+    persist_warnings = [r for r in warnings if "in memory" in r.getMessage()]
+    assert len(persist_warnings) == 1, f"Expected 1, got {len(persist_warnings)}"
+    # Subsequent failures downgrade to DEBUG (so don't spam production logs)
+    debug_repeats = [
+        r for r in caplog.records if r.levelname == "DEBUG" and "still failing" in r.getMessage()
+    ]
+    assert len(debug_repeats) >= 1  # at least one repeat logged at DEBUG
+
+
+@pytest.mark.ws_auth_raw_seed
+def test_rotate_token_survives_unwritable_dir(monkeypatch):
+    """Admin clicks regenerate with unwritable disk → new token lives in memory."""
+    _force_permission_error(monkeypatch)
+    ws_auth._reset_for_tests()
+    ws_auth.set_state(require_token=True, token="original-token-abc")
+    rotated = ws_auth.rotate_token()
+    assert rotated["require_token"] is True
+    assert rotated["token"] != "original-token-abc"
+    assert len(rotated["token"]) >= 16

--- a/setup.sh
+++ b/setup.sh
@@ -446,6 +446,24 @@ _init() {
   echo ""
   _ok ".env written."
 
+  # Bind-mount prep: ensure runtime/ and user_plugins/ exist on the host
+  # with ownership that matches the container's non-root user (uid 1000,
+  # `appuser`). If host `$(id -u)` is different (common on Oracle Cloud
+  # images where the default user is UID 1001), docker will mount dirs
+  # owned by the host user and the container can't write — ws_auth.json
+  # seeding fails silently until admin notices the error log.
+  mkdir -p server/runtime server/user_plugins
+  local _APP_UID=1000 _host_uid
+  _host_uid=$(id -u)
+  if [ "$_host_uid" -ne "$_APP_UID" ]; then
+    _warn "Host uid ($_host_uid) differs from container appuser uid ($_APP_UID)."
+    _warn "Container will fail to write runtime/ws_auth.json, runtime/settings.json,"
+    _warn "runtime/webhooks.json, etc. unless the host dirs match uid $_APP_UID."
+    _warn "Fix before 'docker compose up -d':"
+    echo "    sudo chown -R ${_APP_UID}:${_APP_UID} server/runtime server/user_plugins"
+    echo ""
+  fi
+
   # Traefik acme.json
   if [ "$_PROFILE" = "traefik" ]; then
     mkdir -p traefik


### PR DESCRIPTION
## Summary

Three real bugs caught during a live Oracle Cloud deploy today where the combination silently hid the root cause:

1. **`.env.example` empty-value + inline comment** → python-dotenv loads `"# comment"` as the literal value. `SECRET_KEY=` and `WS_AUTH_TOKEN=` both affected; admin UI showed `"# Shared secret; ..."` as the token. Fixed by moving comments to their own line above each variable.
2. **`setup.sh` didn't detect UID mismatch** → Oracle Cloud Ubuntu uses UID 1001 for `ubuntu`, not 1000. Container `appuser` is 1000. Bind-mount `server/runtime/` owned by host user → container can't write → `Permission denied` spam, admin changes lost. `setup.sh init` now `mkdir`s the dirs and warns with chown command when `id -u != 1000`.
3. **`ws_auth.py` spammed ERROR logs on every write failure** → now one-shot WARNING with actionable fix, repeats at DEBUG. `set_state` updates in-memory cache even when disk write fails — admin UI changes take effect this process lifetime instead of being silently dropped.

Plus:
- `DEPLOYMENT.md` gains troubleshooting entries for both UID mismatch and cloud firewall (iptables + security list).
- `server/package.json` `build:css` appends `\n` so pre-commit `end-of-file-fixer` stops eating commits (v4.8.0 + v4.8.1 both hit this).

Fixes the exact symptoms user hit on `138.2.59.206`.

## Test plan

- [x] `tests/test_ws_auth.py` — 4 new graceful-degradation tests via `monkeypatch.setattr(os, 'open', ...)` forcing PermissionError on `ws_auth.tmp.*`. Covers: seed failure (memory-only continues), set_state failure (in-memory cache updates), one-shot log, rotate in memory-only mode.
- [x] Full suite: **737 passed** (v4.8.1: 733 + 4 new)
- [x] Lint clean (black + flake8)
- [x] Verified against user's live VPS after applying the unblock (chown + recreate) — admin UI WS token toggle round-trip works, WS enforcement works (no-token/wrong-token/correct-token all behave correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Setup script now detects UID mismatches and provides corrective commands.

* **Bug Fixes**
  * Auth state persistence gracefully degrades when filesystem permissions are restricted; in-memory cache updates remain effective.
  * Fixed CSS build formatting issue.

* **Documentation**
  * Enhanced deployment troubleshooting guide with solutions for permission and firewall-blocking issues.
  * Clarified environment variable configuration requirements.

* **Tests**
  * Added coverage for graceful degradation when runtime directory is unwritable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->