### PR TITLE
fix(v4.8.4): nginx Host: $host → $http_host preserves non-standard port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@
 
 ## [Unreleased]
 
+## [4.8.4] - 2026-04-20
+
+### 修復 / Fixed
+
+- **nginx `Host: $host` 丟 port → Flask redirect 走到錯 port (CRITICAL)**：
+  v4.8.3 的 ProxyFix 讓 `/admin → /admin/` redirect 走 HTTPS 了，但 nginx
+  用 `proxy_set_header Host $host;` 把 port **剝掉**（`$host` 只有 hostname，
+  不含 port）。Flask 看到 `Host: 138.2.59.206`，redirect 預設 HTTPS →
+  `https://138.2.59.206/admin/` → 443 → 在 shared-host 環境（例如 Oracle
+  Cloud 同 VM 跑 netbird-caddy 或其他 web service 在 443）會被別的服務接走。
+
+  修法：兩個 nginx config（`nginx-https.conf` + `nginx.conf`）把
+  `proxy_set_header Host $host;` 改成 `proxy_set_header Host $http_host;`，
+  `$http_host` 包含 client 實際連的 port。額外 `X-Forwarded-Host $http_host`
+  讓 ProxyFix 有精確 fallback。
+
+  使用者症狀：v4.8.3 部署後 `https://<ip>:4000/admin` 在 port-only
+  deployment（沒 domain，走非標準 port）會被同機 443 服務攔截。改完
+  `curl -L https://<ip>:4000/admin` 會正確落在 `https://<ip>:4000/admin/`。
+
+---
+
 ## [4.8.3] - 2026-04-20
 
 ### 修復 / Fixed

--- a/danmu-desktop/package.json
+++ b/danmu-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danmu-desktop",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "description": "Danmu overlay controller for live streaming",
   "main": "dist/main.bundle.js",
   "scripts": {

--- a/nginx/nginx-https.conf
+++ b/nginx/nginx-https.conf
@@ -52,11 +52,10 @@ http {
       set $danmu_ws "server";
       proxy_pass http://$danmu_ws:4001/;
       proxy_http_version 1.1;
-      # `$http_host` preserves the non-default port (e.g. 4000) that the
-      # client connected to. Using bare `$host` strips the port, so
-      # Flask's url_for()-based redirects (e.g. GET /admin → /admin/)
-      # generate `Location: https://<ip>/admin/` (port 443) and land on
-      # whatever else occupies 443 on the box (netbird-caddy, etc.).
+      # Use `$http_host` (not `$host`) — see the detailed comment in the
+      # HTTP `location /` block below. Same reason applies to the WS
+      # handshake: upstream needs the original host:port to generate
+      # correct self-referencing URLs on reconnect redirects.
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-Host $http_host;
       proxy_set_header X-Forwarded-For $remote_addr;

--- a/nginx/nginx-https.conf
+++ b/nginx/nginx-https.conf
@@ -52,7 +52,13 @@ http {
       set $danmu_ws "server";
       proxy_pass http://$danmu_ws:4001/;
       proxy_http_version 1.1;
-      proxy_set_header Host $host;
+      # `$http_host` preserves the non-default port (e.g. 4000) that the
+      # client connected to. Using bare `$host` strips the port, so
+      # Flask's url_for()-based redirects (e.g. GET /admin → /admin/)
+      # generate `Location: https://<ip>/admin/` (port 443) and land on
+      # whatever else occupies 443 on the box (netbird-caddy, etc.).
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Host $http_host;
       proxy_set_header X-Forwarded-For $remote_addr;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header Upgrade $http_upgrade;
@@ -66,7 +72,13 @@ http {
       set $danmu_http "server";
       proxy_pass http://$danmu_http:4000;
       proxy_http_version 1.1;
-      proxy_set_header Host $host;
+      # `$http_host` preserves the non-default port (e.g. 4000) that the
+      # client connected to. Using bare `$host` strips the port, so
+      # Flask's url_for()-based redirects (e.g. GET /admin → /admin/)
+      # generate `Location: https://<ip>/admin/` (port 443) and land on
+      # whatever else occupies 443 on the box (netbird-caddy, etc.).
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Host $http_host;
       proxy_set_header X-Forwarded-For $remote_addr;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header Upgrade $http_upgrade;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -36,6 +36,11 @@ http {
       set $http_host_var "server";
       proxy_pass http://$http_host_var:4000;
       proxy_http_version 1.1;
+      # Use `$http_host` (not `$host`) to preserve the port the client
+      # actually connected to. Required for correct Flask redirects on
+      # non-standard ports (e.g. a port-only deployment on 4000) and for
+      # Trusted-Hosts validation when TRUSTED_HOSTS includes `:port`.
+      # See nginx-https.conf for the longer version of this explanation.
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-Host $http_host;
       proxy_set_header X-Forwarded-For $remote_addr;
@@ -55,6 +60,11 @@ http {
       set $ws_host_var "server";
       proxy_pass http://$ws_host_var:4001;
       proxy_http_version 1.1;
+      # Use `$http_host` (not `$host`) to preserve the port the client
+      # actually connected to. Required for correct Flask redirects on
+      # non-standard ports (e.g. a port-only deployment on 4000) and for
+      # Trusted-Hosts validation when TRUSTED_HOSTS includes `:port`.
+      # See nginx-https.conf for the longer version of this explanation.
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-Host $http_host;
       proxy_set_header X-Forwarded-For $remote_addr;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -36,7 +36,8 @@ http {
       set $http_host_var "server";
       proxy_pass http://$http_host_var:4000;
       proxy_http_version 1.1;
-      proxy_set_header Host $host;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Host $http_host;
       proxy_set_header X-Forwarded-For $remote_addr;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header Upgrade $http_upgrade;
@@ -54,7 +55,8 @@ http {
       set $ws_host_var "server";
       proxy_pass http://$ws_host_var:4001;
       proxy_http_version 1.1;
-      proxy_set_header Host $host;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Host $http_host;
       proxy_set_header X-Forwarded-For $remote_addr;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header Upgrade $http_upgrade;

--- a/server/config.py
+++ b/server/config.py
@@ -39,7 +39,7 @@ class Config:
     # Priority: runtime hash file > ADMIN_PASSWORD_HASHED env var > plaintext ADMIN_PASSWORD
     ADMIN_PASSWORD_HASHED = load_runtime_hash() or os.getenv("ADMIN_PASSWORD_HASHED", "")
     APP_NAME = "Danmu Fire"
-    APP_VERSION = "4.8.3"
+    APP_VERSION = "4.8.4"
     PORT = int(os.getenv("PORT", "4000"))
     WS_PORT = int(os.getenv("WS_PORT", "4001"))
     ENV = os.getenv("ENV", "development").lower()


### PR DESCRIPTION
## Summary

v4.8.3's ProxyFix made Flask redirects go HTTPS correctly, but nginx was still using `proxy_set_header Host $host;` which **strips the port**. `$host` returns only the hostname. For a client connecting to `https://<ip>:4000/admin`, nginx passed `Host: 138.2.59.206` to Flask — Flask generated `Location: https://138.2.59.206/admin/` (port 443) → landed on whatever else was bound to 443 on the host (netbird-caddy on Oracle Cloud, shared web services, etc.).

Use `$http_host` which preserves the port client actually connected to. Also set `X-Forwarded-Host` explicitly so ProxyFix (`x_host=1`) has an unambiguous source.

## Verification on user's live VPS (138.2.59.206:4000)

Before:
```
curl -L https://138.2.59.206:4000/admin
→ 308 → https://138.2.59.206/admin/ (port 443) → netbird 404
```

After:
```
curl -L https://138.2.59.206:4000/admin
→ 200 https://138.2.59.206:4000/admin/ (correct)
```

## Test plan

- [x] Live-patched user's VPS, verified `/admin` no longer redirects to port 443
- [ ] CI build + test suite on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed critical nginx proxy header issue affecting HTTPS redirects on non-default port deployments
  * Updated host header forwarding to upstream services

* **Chores**
  * Bumped application version to 4.8.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->