### PR TITLE
feat(v4.9.1): /fire anti-abuse layers + slido-extension admin token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,8 +80,21 @@ WS_MAX_CONNECTIONS_PER_IP=10
 
 # === Rate Limiting ===
 
-FIRE_RATE_LIMIT=20          # Messages per window
+FIRE_RATE_LIMIT=20          # Public per-IP: messages per window
 FIRE_RATE_WINDOW=60         # Window in seconds
+# Per-fingerprint limit (catches IP-rotating spammers). 0 disables.
+# FIRE_FINGERPRINT_RATE_LIMIT=30
+# FIRE_FINGERPRINT_RATE_WINDOW=60
+# Global ceiling across ALL public clients (distributed flood protection). 0 disables.
+# GLOBAL_FIRE_RATE_LIMIT=0
+# GLOBAL_FIRE_RATE_WINDOW=60
+# Admin fast-lane: requests with matching X-Fire-Token header bypass public
+# per-IP / per-fingerprint / global limits and captcha. Still rate-limited on
+# its own ceiling to stop buggy extensions from runaway-looping. Leave empty
+# to disable the lane entirely (header will be ignored).
+# FIRE_ADMIN_TOKEN=
+# FIRE_ADMIN_RATE_LIMIT=200
+# FIRE_ADMIN_RATE_WINDOW=60
 # ADMIN_RATE_LIMIT=60
 # ADMIN_RATE_WINDOW=60
 # API_RATE_LIMIT=30
@@ -89,6 +102,14 @@ FIRE_RATE_WINDOW=60         # Window in seconds
 # LOGIN_RATE_LIMIT=5        # Failed login attempts before lockout
 # LOGIN_RATE_WINDOW=300     # Lockout window in seconds (5 minutes)
 RATE_LIMIT_BACKEND=memory   # Options: memory, redis
+
+# === Captcha (public /fire gate) ===
+# Optional Turnstile / hCaptcha gate in front of /fire. Leave provider=none to
+# disable. When enabled, public clients must attach a `captcha_token` in the
+# POST body. Admin lane (X-Fire-Token) skips this check.
+# CAPTCHA_PROVIDER=none       # Options: none, turnstile, hcaptcha
+# CAPTCHA_SITE_KEY=           # Public key rendered in overlay/admin UI
+# CAPTCHA_SECRET=             # Server-side secret used for siteverify
 
 # Redis (only when RATE_LIMIT_BACKEND=redis)
 # Docker: redis://:PASSWORD@redis:6379/0  (use service name "redis")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@
 
 ## [Unreleased]
 
+## [4.9.1] - 2026-04-22
+
+`/fire` anti-abuse hardening — 在 v4.9.0 admin observability 之後，補齊公開
+`/fire` endpoint 面對 WAN 部署 / 瀏覽器 extension 量產時需要的濫用防線。
+Server-only release（`danmu-desktop/package.json` 未 bump → 不觸發 Electron
+binary build）。
+
+### 新增 / Added
+
+- **Per-fingerprint rate limit**：在既有 per-IP ceiling 之上新增
+  `FIRE_FINGERPRINT_RATE_LIMIT` / `FIRE_FINGERPRINT_RATE_WINDOW`（預設 30/60s）
+  捕捉 IP 輪替的單一攻擊者（mobile hotspot、residential proxy pool）。0 = 關閉。
+- **Global rate limit ceiling**：`GLOBAL_FIRE_RATE_LIMIT` / `GLOBAL_FIRE_RATE_WINDOW`
+  （預設 0/關閉）跨所有 public 客戶端的全域上限，針對分散式 flood 用。
+- **Admin fast-lane (`X-Fire-Token`)**：`FIRE_ADMIN_TOKEN` 環境變數啟用後，帶
+  對應 header 的請求繞過 public per-IP / per-fingerprint / global 限制 + captcha，
+  但有自己的 ceiling（`FIRE_ADMIN_RATE_LIMIT`，預設 200/60s）防止 buggy extension
+  runaway loop。用 `secrets.compare_digest` 做 timing-safe 比對。
+- **Captcha gate**：`CAPTCHA_PROVIDER` 支援 `none` / `turnstile` / `hcaptcha`。啟用後
+  public 端必須在 `/fire` body 夾帶 `captcha_token`，server 用 `urllib.request` 呼叫
+  `siteverify` 驗證。Admin lane 跳過。secret 缺失時 fail-open（logged warning）
+  避免 typo 直接把 server 打掛。
+- **Slido extension v0.2.0**：popup 新增 **Fire Token** 欄位，填了後 extension
+  打 `/fire` 會帶 `X-Fire-Token` header 走 admin 通道。README 更新說明用法。
+
+### 改善 / Changed
+
+- **`routes/api.py::fire`**：移除 `@rate_limit("fire")` decorator，改為 inline
+  呼叫 `enforce_fire_rate_limits(fingerprint, is_admin)` 統一處理四層防線。
+  在 `try/except` 前面新增 `except HTTPException: raise`，避免 `abort(429)` 被
+  外層 `except Exception` 吞成 500。
+- **`services/validation.py::FireRequestSchema`**：新增 `captcha_token` 欄位
+  （optional，max 8192 chars）。
+- **`.env.example`**：記錄 7 個新環境變數 + captcha provider 區塊。
+- **`app.py`**：`inject_security_template_state` context_processor 暴露
+  `captcha_provider` / `captcha_site_key` 給模板（後續讓 overlay/admin 能自動
+  render widget）。
+
+### 驗證 / Verification
+
+- 803 tests pass（新增 12 個 `test_fire_abuse_protection.py` 覆蓋 admin-bypass、
+  token-mismatch-fallback、admin-ceiling、no-token-configured、fingerprint-catches-
+  IP-rotation、fingerprint-0-disables、global-trips-across-IPs、global-admin-bypasses、
+  captcha-rejects、captcha-approves、captcha-admin-skips、captcha-disabled-default）
+- `APP_VERSION` bumped to 4.9.1（server-only — `package.json` 維持 4.9.0，
+  不觸發 `build.yml` 的 Electron binary release pipeline）
+
+### 為什麼 / Why
+
+主要用途是會開放到 WAN 給大家使用 — 單一 per-IP limit 擋不住 IP 輪替攻擊，
+也擋不住分散式 flood。Admin fast-lane 讓主持人/extension 操作者不會被同一套
+public 防線擋住。四層（admin bypass → per-IP → per-fingerprint → global → captcha）
+組合起來才能覆蓋實際部署場景。
+
+---
+
 ## [4.9.0] - 2026-04-21
 
 Admin observability bundle — 五支面向維運者的工具一次打包，server-only release

--- a/server/app.py
+++ b/server/app.py
@@ -147,6 +147,8 @@ def create_app(config_class=Config):
             "csp_nonce": getattr(g, "csp_nonce", ""),
             "app_version": Config.APP_VERSION,
             "app_name": Config.APP_NAME,
+            "captcha_provider": Config.CAPTCHA_PROVIDER,
+            "captcha_site_key": Config.CAPTCHA_SITE_KEY,
         }
 
     @app.after_request

--- a/server/config.py
+++ b/server/config.py
@@ -39,7 +39,7 @@ class Config:
     # Priority: runtime hash file > ADMIN_PASSWORD_HASHED env var > plaintext ADMIN_PASSWORD
     ADMIN_PASSWORD_HASHED = load_runtime_hash() or os.getenv("ADMIN_PASSWORD_HASHED", "")
     APP_NAME = "Danmu Fire"
-    APP_VERSION = "4.9.0"
+    APP_VERSION = "4.9.1"
     PORT = int(os.getenv("PORT", "4000"))
     WS_PORT = int(os.getenv("WS_PORT", "4001"))
     ENV = os.getenv("ENV", "development").lower()
@@ -47,6 +47,26 @@ class Config:
     WS = ""
     FIRE_RATE_LIMIT = int(os.getenv("FIRE_RATE_LIMIT", "20"))
     FIRE_RATE_WINDOW = int(os.getenv("FIRE_RATE_WINDOW", "60"))
+    # Per-fingerprint ceiling (0 disables). Stops users who rotate IPs
+    # (VPN / mobile) from bypassing per-IP limits via /fire.
+    FIRE_FINGERPRINT_RATE_LIMIT = int(os.getenv("FIRE_FINGERPRINT_RATE_LIMIT", "30"))
+    FIRE_FINGERPRINT_RATE_WINDOW = int(os.getenv("FIRE_FINGERPRINT_RATE_WINDOW", "60"))
+    # Global ceiling across all clients (0 disables). Protects the overlay
+    # from distributed-IP floods that individually stay under per-IP caps.
+    GLOBAL_FIRE_RATE_LIMIT = int(os.getenv("GLOBAL_FIRE_RATE_LIMIT", "0"))
+    GLOBAL_FIRE_RATE_WINDOW = int(os.getenv("GLOBAL_FIRE_RATE_WINDOW", "60"))
+    # Shared secret for privileged /fire clients (e.g. Slido extension).
+    # If set, requests with a matching `X-Fire-Token` header skip the
+    # public rate limits and captcha, using the higher admin ceiling below.
+    # Empty string disables the admin lane entirely.
+    FIRE_ADMIN_TOKEN = os.getenv("FIRE_ADMIN_TOKEN", "")
+    FIRE_ADMIN_RATE_LIMIT = int(os.getenv("FIRE_ADMIN_RATE_LIMIT", "200"))
+    FIRE_ADMIN_RATE_WINDOW = int(os.getenv("FIRE_ADMIN_RATE_WINDOW", "60"))
+    # Captcha verification for public /fire (extension admin lane bypasses).
+    # Provider: "none" (default, disabled), "turnstile", "hcaptcha".
+    CAPTCHA_PROVIDER = os.getenv("CAPTCHA_PROVIDER", "none").lower()
+    CAPTCHA_SITE_KEY = os.getenv("CAPTCHA_SITE_KEY", "")
+    CAPTCHA_SECRET = os.getenv("CAPTCHA_SECRET", "")
     ADMIN_RATE_LIMIT = int(os.getenv("ADMIN_RATE_LIMIT", "60"))
     ADMIN_RATE_WINDOW = int(os.getenv("ADMIN_RATE_WINDOW", "60"))
     API_RATE_LIMIT = int(os.getenv("API_RATE_LIMIT", "30"))

--- a/server/routes/api.py
+++ b/server/routes/api.py
@@ -2,6 +2,7 @@ import html
 import re
 
 from flask import Blueprint, current_app, make_response, request, send_from_directory, session
+from werkzeug.exceptions import HTTPException
 
 from .. import state
 from ..services import fingerprint_tracker
@@ -18,7 +19,14 @@ from ..services.ip import get_client_ip as _extract_client_ip
 from ..services.layout import get_all_modes, get_layout_config, get_layout_css
 from ..services.plugin_manager import plugin_manager
 from ..services.poll import poll_service
-from ..services.security import rate_limit, require_csrf, verify_font_token
+from ..services.security import (
+    enforce_fire_rate_limits,
+    is_fire_admin,
+    rate_limit,
+    require_csrf,
+    verify_captcha,
+    verify_font_token,
+)
 from ..services.settings import get_options
 from ..services.sound import sound_service
 from ..services.stickers import sticker_service
@@ -201,11 +209,14 @@ def _record_history_if_enabled(data, fingerprint, client_ip):
     history_service.danmu_history.add(history_payload)
 
 
-# NOTE: /fire is a public endpoint (no auth required) — CSRF protection is
-# intentionally omitted. Rate limiting + fingerprint tracking provide abuse
-# protection. Do NOT add @require_csrf here.
+# NOTE: /fire is a public endpoint (no session auth required) — CSRF protection
+# is intentionally omitted. Abuse protection instead layered as: per-IP rate
+# limit, per-fingerprint rate limit, global rate limit, and optional captcha.
+# Clients with a valid `X-Fire-Token` header bypass the public ceiling and use
+# the admin lane (also rate-limited, but more generously). Do NOT add
+# @require_csrf or @rate_limit decorators — all checks run inline so the admin
+# token can bypass them before limits are charged.
 @api_bp.route("/fire", methods=["POST"])
-@rate_limit("fire")
 def fire():
     """發送彈幕"""
     if get_ws_client_count() <= 0:
@@ -225,9 +236,21 @@ def fire():
             return _internal_plain_error_response()
 
         fingerprint = data.pop("fingerprint", None)
+        captcha_token = data.pop("captcha_token", None)
         text_content = data.get("text", "")
         client_ip = _extract_client_ip()
         user_agent = request.headers.get("User-Agent", "")
+
+        admin_client = is_fire_admin()
+
+        # Captcha gate (public only; admin lane skips).
+        if not admin_client:
+            header_captcha = request.headers.get("X-Captcha-Token")
+            if not verify_captcha(captcha_token or header_captcha):
+                return _json_response({"error": "Captcha verification failed"}, 400)
+
+        # Rate-limit chain. Aborts 429 internally; flask converts to response.
+        enforce_fire_rate_limits(fingerprint, admin_client)
 
         # Filter engine check (replaces simple blacklist check)
         filter_result = filter_engine.check(text_content, fingerprint)
@@ -294,6 +317,9 @@ def fire():
 
             return _json_response({"status": "OK"}, 200)
         return _json_response({"error": "Failed to enqueue message"}, 503)
+    except HTTPException:
+        # Rate-limit aborts (429) and similar must propagate verbatim.
+        raise
     except Exception as exc:
         return _log_and_internal_error("Send Error", exc)
 

--- a/server/services/security.py
+++ b/server/services/security.py
@@ -4,6 +4,8 @@ import logging
 import secrets
 import threading
 import time
+import urllib.parse
+import urllib.request
 from collections import defaultdict, deque
 from functools import wraps
 
@@ -186,6 +188,119 @@ def rate_limit(
         return wrapper
 
     return decorator
+
+
+def is_fire_admin() -> bool:
+    """Return True when the request carries a matching X-Fire-Token header.
+
+    Admin requests bypass public /fire rate limits and captcha. Returns
+    False (public client) when no admin token is configured or the header
+    is missing/mismatched. Uses secrets.compare_digest to resist timing
+    attacks.
+    """
+    expected = (current_app.config.get("FIRE_ADMIN_TOKEN") or "").strip()
+    if not expected:
+        return False
+    provided = (request.headers.get("X-Fire-Token") or "").strip()
+    if not provided:
+        return False
+    try:
+        return secrets.compare_digest(expected, provided)
+    except Exception:
+        return False
+
+
+def enforce_fire_rate_limits(fingerprint: str | None, is_admin: bool) -> None:
+    """Apply the full /fire rate-limit chain. Aborts 429 if any is exceeded.
+
+    - Admin lane: one generous per-IP ceiling, no captcha, no per-fingerprint,
+      no global cap. Stops buggy extensions from runaway-looping without
+      blocking organizers behind a public surge.
+    - Public lane: per-IP (existing), per-fingerprint (new), global (new).
+      Any of the three tripping is enough to reject.
+    """
+    cfg = current_app.config
+    client_ip = _get_client_ip()
+
+    if is_admin:
+        limit = int(cfg.get("FIRE_ADMIN_RATE_LIMIT", 200))
+        window = int(cfg.get("FIRE_ADMIN_RATE_WINDOW", 60))
+        if limit > 0 and not rate_limiter.allow(
+            f"fire_admin:{client_ip}", limit, window
+        ):
+            abort(429, description="Too Many Requests")
+        return
+
+    # Per-IP ceiling (mirrors the pre-v4.9.1 decorator behaviour).
+    ip_limit = int(cfg.get("FIRE_RATE_LIMIT", 20))
+    ip_window = int(cfg.get("FIRE_RATE_WINDOW", 60))
+    if ip_limit > 0 and not rate_limiter.allow(
+        f"fire:{client_ip}", ip_limit, ip_window
+    ):
+        abort(429, description="Too Many Requests")
+
+    fp_limit = int(cfg.get("FIRE_FINGERPRINT_RATE_LIMIT", 0))
+    fp_window = int(cfg.get("FIRE_FINGERPRINT_RATE_WINDOW", 60))
+    if fp_limit > 0 and fingerprint:
+        if not rate_limiter.allow(f"fire_fp:{fingerprint}", fp_limit, fp_window):
+            abort(429, description="Too Many Requests")
+
+    global_limit = int(cfg.get("GLOBAL_FIRE_RATE_LIMIT", 0))
+    global_window = int(cfg.get("GLOBAL_FIRE_RATE_WINDOW", 60))
+    if global_limit > 0:
+        if not rate_limiter.allow("fire_global:all", global_limit, global_window):
+            abort(429, description="Too Many Requests")
+
+
+def verify_captcha(token: str | None) -> bool:
+    """Verify a Turnstile / hCaptcha token.
+
+    Returns True when:
+      - no provider is configured (feature disabled)
+      - provider is configured but secret is missing (misconfig -> fail open
+        so server doesn't become unusable on typo; logged at WARNING)
+      - provider verifies the token successfully
+
+    Returns False only when the provider actively rejects the token or
+    the HTTP call errors. Caller translates False → 400.
+    """
+    cfg = current_app.config
+    provider = (cfg.get("CAPTCHA_PROVIDER") or "none").lower()
+    if provider == "none":
+        return True
+    secret = (cfg.get("CAPTCHA_SECRET") or "").strip()
+    if not secret:
+        logger.warning(
+            "CAPTCHA_PROVIDER=%s set but CAPTCHA_SECRET empty — skipping verification",
+            provider,
+        )
+        return True
+    if not token:
+        return False
+
+    if provider == "turnstile":
+        url = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+    elif provider == "hcaptcha":
+        url = "https://hcaptcha.com/siteverify"
+    else:
+        logger.warning("Unknown CAPTCHA_PROVIDER=%s — skipping verification", provider)
+        return True
+
+    try:
+        data = urllib.parse.urlencode(
+            {
+                "secret": secret,
+                "response": token,
+                "remoteip": _get_client_ip() or "",
+            }
+        ).encode()
+        req = urllib.request.Request(url, data=data, method="POST")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            payload = json.loads(resp.read().decode("utf-8") or "{}")
+        return bool(payload.get("success"))
+    except Exception as exc:
+        logger.warning("captcha verify error (%s): %s", provider, exc)
+        return False
 
 
 def hash_password(password: str) -> str:

--- a/server/services/validation.py
+++ b/server/services/validation.py
@@ -35,6 +35,9 @@ class FireRequestSchema(Schema):
     size = fields.Int(load_default=None, validate=validate.Range(min=1, max=200))
     speed = fields.Int(load_default=None, validate=validate.Range(min=1, max=10))
     fingerprint = fields.Str(load_default=None, validate=validate.Length(max=128))
+    # Captcha providers (Turnstile / hCaptcha) issue tokens well under 4k chars.
+    # Accept anything up to 8k to be safe; verification itself is the real gate.
+    captcha_token = fields.Str(load_default=None, validate=validate.Length(max=8192))
     nickname = fields.Str(load_default=None, validate=validate.Length(max=20))
     layout = fields.Str(
         load_default=None,

--- a/server/tests/test_fire_abuse_protection.py
+++ b/server/tests/test_fire_abuse_protection.py
@@ -1,0 +1,194 @@
+"""Tests for /fire anti-abuse layers added in v4.9.1:
+
+- X-Fire-Token admin lane bypasses public rate limits + captcha
+- Per-fingerprint rate limit (catches IP-rotating spammers)
+- Global rate limit (ceiling for distributed floods)
+- Captcha (Turnstile / hCaptcha) gate
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from server.services.ws_state import update_ws_client_count
+
+
+PAYLOAD = {"text": "hello", "fontInfo": {"name": "NotoSansTC"}, "isImage": False}
+
+
+@pytest.fixture()
+def overlay_connected():
+    update_ws_client_count(1)
+    yield
+    update_ws_client_count(0)
+
+
+def _post(client, payload=None, headers=None, ip="1.1.1.1"):
+    return client.post(
+        "/fire",
+        json=payload if payload is not None else PAYLOAD,
+        headers=headers or {},
+        environ_base={"REMOTE_ADDR": ip},
+    )
+
+
+# --- Admin token bypass ------------------------------------------------------
+
+
+def test_admin_token_bypasses_public_rate_limit(app, client, overlay_connected):
+    # conftest.TestConfig sets FIRE_RATE_LIMIT = 2. Admin should blow past it.
+    app.config["FIRE_ADMIN_TOKEN"] = "admin-secret"
+    app.config["FIRE_ADMIN_RATE_LIMIT"] = 100
+
+    headers = {"X-Fire-Token": "admin-secret"}
+    for _ in range(6):
+        r = _post(client, headers=headers)
+        assert r.status_code == 200, r.data
+
+
+def test_admin_token_mismatch_falls_back_to_public_limit(
+    app, client, overlay_connected
+):
+    app.config["FIRE_ADMIN_TOKEN"] = "admin-secret"
+
+    headers = {"X-Fire-Token": "wrong"}
+    assert _post(client, headers=headers).status_code == 200
+    assert _post(client, headers=headers).status_code == 200
+    # Third request from the same IP hits public FIRE_RATE_LIMIT=2
+    assert _post(client, headers=headers).status_code == 429
+
+
+def test_admin_token_has_own_ceiling(app, client, overlay_connected):
+    app.config["FIRE_ADMIN_TOKEN"] = "admin-secret"
+    app.config["FIRE_ADMIN_RATE_LIMIT"] = 2  # force a low admin ceiling
+    app.config["FIRE_ADMIN_RATE_WINDOW"] = 60
+
+    headers = {"X-Fire-Token": "admin-secret"}
+    assert _post(client, headers=headers).status_code == 200
+    assert _post(client, headers=headers).status_code == 200
+    assert _post(client, headers=headers).status_code == 429
+
+
+def test_no_admin_token_configured_means_header_ignored(app, client, overlay_connected):
+    app.config["FIRE_ADMIN_TOKEN"] = ""  # feature off
+    headers = {"X-Fire-Token": "anything"}
+    assert _post(client, headers=headers).status_code == 200
+    assert _post(client, headers=headers).status_code == 200
+    assert _post(client, headers=headers).status_code == 429
+
+
+# --- Per-fingerprint rate limit ---------------------------------------------
+
+
+def test_fingerprint_rate_limit_catches_ip_rotation(app, client, overlay_connected):
+    # Give per-IP enough room so this test measures only fingerprint limiting.
+    app.config["FIRE_RATE_LIMIT"] = 100
+    app.config["FIRE_FINGERPRINT_RATE_LIMIT"] = 2
+    app.config["FIRE_FINGERPRINT_RATE_WINDOW"] = 60
+
+    payload = dict(PAYLOAD, fingerprint="fp-attacker")
+
+    assert _post(client, payload=payload, ip="1.1.1.1").status_code == 200
+    assert _post(client, payload=payload, ip="2.2.2.2").status_code == 200
+    # Third request from yet another IP — fingerprint is the trip wire
+    assert _post(client, payload=payload, ip="3.3.3.3").status_code == 429
+
+
+def test_fingerprint_limit_zero_disables(app, client, overlay_connected):
+    app.config["FIRE_RATE_LIMIT"] = 100
+    app.config["FIRE_FINGERPRINT_RATE_LIMIT"] = 0  # disabled
+
+    payload = dict(PAYLOAD, fingerprint="fp-x")
+    for _ in range(5):
+        assert _post(client, payload=payload).status_code == 200
+
+
+# --- Global rate limit -------------------------------------------------------
+
+
+def test_global_rate_limit_trips_across_ips(app, client, overlay_connected):
+    app.config["FIRE_RATE_LIMIT"] = 100
+    app.config["FIRE_FINGERPRINT_RATE_LIMIT"] = 0
+    app.config["GLOBAL_FIRE_RATE_LIMIT"] = 2
+    app.config["GLOBAL_FIRE_RATE_WINDOW"] = 60
+
+    assert _post(client, ip="1.1.1.1").status_code == 200
+    assert _post(client, ip="2.2.2.2").status_code == 200
+    assert _post(client, ip="3.3.3.3").status_code == 429
+
+
+def test_global_rate_limit_admin_bypasses(app, client, overlay_connected):
+    app.config["GLOBAL_FIRE_RATE_LIMIT"] = 1
+    app.config["GLOBAL_FIRE_RATE_WINDOW"] = 60
+    app.config["FIRE_ADMIN_TOKEN"] = "admin-secret"
+    app.config["FIRE_ADMIN_RATE_LIMIT"] = 100
+
+    # One public request trips the global limit immediately afterwards...
+    assert _post(client).status_code == 200
+    assert _post(client, ip="2.2.2.2").status_code == 429
+    # ...but admin is a separate lane and continues to work.
+    headers = {"X-Fire-Token": "admin-secret"}
+    assert _post(client, ip="9.9.9.9", headers=headers).status_code == 200
+
+
+# --- Captcha -----------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, body):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def read(self):
+        return self._body.encode()
+
+
+def test_captcha_blocks_when_provider_rejects(app, client, overlay_connected):
+    app.config["CAPTCHA_PROVIDER"] = "turnstile"
+    app.config["CAPTCHA_SECRET"] = "test-secret"
+
+    with patch(
+        "server.services.security.urllib.request.urlopen",
+        return_value=_FakeResp(json.dumps({"success": False})),
+    ):
+        r = _post(client, payload=dict(PAYLOAD, captcha_token="bad-token"))
+    assert r.status_code == 400
+    assert "Captcha" in r.get_json()["error"]
+
+
+def test_captcha_passes_when_provider_approves(app, client, overlay_connected):
+    app.config["CAPTCHA_PROVIDER"] = "turnstile"
+    app.config["CAPTCHA_SECRET"] = "test-secret"
+
+    with patch(
+        "server.services.security.urllib.request.urlopen",
+        return_value=_FakeResp(json.dumps({"success": True})),
+    ):
+        r = _post(client, payload=dict(PAYLOAD, captcha_token="good-token"))
+    assert r.status_code == 200
+
+
+def test_captcha_admin_lane_skips_verification(app, client, overlay_connected):
+    app.config["CAPTCHA_PROVIDER"] = "turnstile"
+    app.config["CAPTCHA_SECRET"] = "test-secret"
+    app.config["FIRE_ADMIN_TOKEN"] = "admin-secret"
+
+    # urlopen is NOT patched — if admin bypass fails, the real HTTP call would
+    # happen and the test would hang/fail. Success implies bypass worked.
+    r = _post(
+        client,
+        payload=dict(PAYLOAD, fingerprint="ext-bot"),
+        headers={"X-Fire-Token": "admin-secret"},
+    )
+    assert r.status_code == 200
+
+
+def test_captcha_disabled_by_default(app, client, overlay_connected):
+    # Default CAPTCHA_PROVIDER=="none" — no token needed
+    assert _post(client).status_code == 200

--- a/slido-extension/README.md
+++ b/slido-extension/README.md
@@ -28,6 +28,10 @@ main world，hook 三個 transport 並從 JSON response 中遞迴找出
 1. 啟動 danmu-desktop server（預設 `http://localhost:4000`）與 Electron overlay
 2. 點 extension icon 打開 popup：
    - **Server URL**：如果不是本機，改成你的 server 位址
+   - **Fire Token** (選填)：對應 server 的 `FIRE_ADMIN_TOKEN`，填了之後
+     extension 打 `/fire` 會帶 `X-Fire-Token` header，走 admin 快速通道，
+     不受 public per-IP / per-fingerprint / 全域速率限制和 captcha 阻擋。
+     只在你是 server 管理者、extension 跑在公開場合時才需要。
    - **Mode**：先用 `Dry run` 驗證能抓到訊息再切 `Live`
    - **Test /fire**：手動發一則測試彈幕
 3. 打開 Slido 活動頁（`https://app.sli.do/event/...`），開 DevTools console

--- a/slido-extension/README.md
+++ b/slido-extension/README.md
@@ -1,0 +1,71 @@
+# Slido → Danmu Bridge
+
+一個 Chrome MV3 extension，把 Slido 活動頁面上的問題 / 留言 / 投票文字
+即時轉送到本機的 `danmu-desktop` server（`POST /fire`），顯示為彈幕。
+
+## 原理
+
+Slido 的頁面透過 `fetch` / `XMLHttpRequest` / `WebSocket` 與 `*.sli.do`
+API 通訊。Extension 在使用者已登入的 Slido 頁面上注入 `inject.js` 到
+main world，hook 三個 transport 並從 JSON response 中遞迴找出
+`text` / `body` / `question` / `message` / `answer` 等欄位，去重後
+轉發到 `http://localhost:4000/fire`。
+
+- 不用 Slido API key（走使用者自己的登入 session）
+- 不碰 server 認證（`/fire` 是 public endpoint）
+- 在 background service worker 做 dedup（預設 5 分鐘）+ rate limit（預設 800ms）
+- 超過 100 字的訊息自動截斷（符合 `FireRequestSchema` 上限）
+
+## 安裝
+
+1. 打開 `chrome://extensions/`（或 Edge/Brave 對應頁）
+2. 右上角打開「開發人員模式 / Developer mode」
+3. 點「載入未封裝項目 / Load unpacked」
+4. 選這個 `slido-extension/` 目錄
+
+## 使用
+
+1. 啟動 danmu-desktop server（預設 `http://localhost:4000`）與 Electron overlay
+2. 點 extension icon 打開 popup：
+   - **Server URL**：如果不是本機，改成你的 server 位址
+   - **Mode**：先用 `Dry run` 驗證能抓到訊息再切 `Live`
+   - **Test /fire**：手動發一則測試彈幕
+3. 打開 Slido 活動頁（`https://app.sli.do/event/...`），開 DevTools console
+   應該看到 `[slido-danmu] hooks installed`
+4. Slido 上有新問題/留言/投票出現時，就會自動轉成彈幕
+
+## 調整 & 除錯
+
+### 看抓到哪些訊息
+打開 Slido 頁的 DevTools → Console，filter `[slido-danmu]`。
+在 popup 切 `Dry run` 可以只 log 不實際送，適合第一次對 mapping。
+
+### 如果沒抓到訊息
+Slido API schema 可能改了。開 DevTools → Network 面板看 Slido 打的
+XHR/Fetch/WS，找出實際的 JSON 路徑，然後在 `inject.js` 的
+`TEXT_FIELDS` / `AUTHOR_FIELDS` set 裡加欄位名。
+
+### Server 拒收
+- 檢查 popup 的 Test /fire 結果
+- 檢查 server log：可能是 rate limit、黑名單關鍵字、或 overlay 沒連線
+- `/fire` 會在沒有 overlay 連線時回 503
+
+## 權限說明
+
+- `storage` — 儲存 server URL / mode 等設定
+- `scripting` — 注入 main-world hook
+- `host_permissions`
+  - `*.sli.do`, `*.slido.com` — content script 只在這些網域跑
+  - `http://*/*`, `https://*/*` — 讓 service worker 能 POST 到任意
+    使用者配置的 danmu server（本機 / LAN / 遠端）。
+    如果只用本機，可以把這個收窄成 `http://localhost/*` + `http://127.0.0.1/*`。
+
+## 已知限制
+
+- 只攔截字串型 JSON 與 WS text frame；binary frames（protobuf）無法解析
+- Slido 偶爾會改 API 欄位名 → 需要手動 tune `TEXT_FIELDS`
+- 依賴 main-world hook；如果 Slido 未來加 CSP 或 iframe sandbox 限制，注入會失敗
+
+## 授權
+
+與 repo 同授權。

--- a/slido-extension/background.js
+++ b/slido-extension/background.js
@@ -1,0 +1,158 @@
+// Service worker: receives candidate messages from content scripts, dedups
+// them, applies filters, and POSTs to the danmu-desktop /fire endpoint.
+
+const DEFAULTS = {
+  enabled: true,
+  serverUrl: "http://localhost:4000",
+  mode: "live",          // "live" | "dry-run"
+  includeAuthor: true,
+  minIntervalMs: 800,    // per-message send floor (rate limit)
+  dedupTtlMs: 5 * 60_000,
+  maxTextLen: 100,       // server FireRequestSchema caps at 100
+  color: "",             // empty = server/theme default
+  opacity: null,
+  size: null,
+  speed: null,
+};
+
+const seen = new Map();        // key -> timestamp
+let lastSendAt = 0;
+let recentStats = { forwarded: 0, skipped: 0, errors: 0, lastError: "" };
+
+async function getSettings() {
+  const stored = await chrome.storage.local.get(["settings"]);
+  return { ...DEFAULTS, ...(stored.settings || {}) };
+}
+
+function pruneSeen(ttl) {
+  const cutoff = Date.now() - ttl;
+  for (const [k, t] of seen) {
+    if (t < cutoff) seen.delete(k);
+  }
+}
+
+function stableKey(cand) {
+  if (cand.id) return `id:${cand.id}`;
+  // Fall back to content hash-ish key. Good enough for 5-min dedup.
+  const text = (cand.text || "").slice(0, 160).trim().toLowerCase();
+  const author = (cand.author || "").slice(0, 40).trim().toLowerCase();
+  return `t:${author}|${text}`;
+}
+
+function truncate(text, max) {
+  if (!text) return text;
+  const s = String(text).replace(/\s+/g, " ").trim();
+  if (s.length <= max) return s;
+  return s.slice(0, Math.max(1, max - 1)) + "…";
+}
+
+function composeDanmuText(cand, settings) {
+  const base = truncate(cand.text || "", settings.maxTextLen);
+  if (!settings.includeAuthor || !cand.author) return base;
+  const prefix = `${cand.author}: `;
+  const room = settings.maxTextLen - prefix.length;
+  if (room < 4) return base; // not worth prefixing
+  return prefix + truncate(cand.text, room);
+}
+
+function buildPayload(text, settings) {
+  const payload = { text };
+  if (settings.color) payload.color = settings.color;
+  if (Number.isInteger(settings.opacity)) payload.opacity = settings.opacity;
+  if (Number.isInteger(settings.size)) payload.size = settings.size;
+  if (Number.isInteger(settings.speed)) payload.speed = settings.speed;
+  payload.fingerprint = "slido-extension";
+  return payload;
+}
+
+async function postFire(serverUrl, payload) {
+  const url = serverUrl.replace(/\/+$/, "") + "/fire";
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+    // credentials intentionally omitted: /fire is public, no cookies needed.
+  });
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => "");
+    throw new Error(`HTTP ${resp.status}: ${body.slice(0, 200)}`);
+  }
+  return true;
+}
+
+async function handleCandidates(candidates) {
+  const settings = await getSettings();
+  if (!settings.enabled) return;
+  if (!Array.isArray(candidates) || !candidates.length) return;
+
+  pruneSeen(settings.dedupTtlMs);
+
+  for (const cand of candidates) {
+    const key = stableKey(cand);
+    if (seen.has(key)) {
+      recentStats.skipped++;
+      continue;
+    }
+    seen.set(key, Date.now());
+
+    const text = composeDanmuText(cand, settings);
+    if (!text) {
+      recentStats.skipped++;
+      continue;
+    }
+
+    // Per-message rate-limit floor (server also rate-limits; this avoids
+    // hammering it when Slido dumps a backlog on page load).
+    const now = Date.now();
+    const gap = now - lastSendAt;
+    if (gap < settings.minIntervalMs) {
+      await new Promise((r) => setTimeout(r, settings.minIntervalMs - gap));
+    }
+    lastSendAt = Date.now();
+
+    const payload = buildPayload(text, settings);
+
+    if (settings.mode === "dry-run") {
+      console.info("[slido-danmu] dry-run", payload);
+      recentStats.forwarded++;
+      continue;
+    }
+
+    try {
+      await postFire(settings.serverUrl, payload);
+      recentStats.forwarded++;
+    } catch (err) {
+      recentStats.errors++;
+      recentStats.lastError = String(err.message || err);
+      console.warn("[slido-danmu] POST failed", err);
+    }
+  }
+}
+
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  if (msg && msg.type === "slido_candidates") {
+    handleCandidates(msg.candidates).catch((err) =>
+      console.warn("[slido-danmu] handler error", err),
+    );
+    sendResponse({ ok: true });
+    return true;
+  }
+  if (msg && msg.type === "get_stats") {
+    sendResponse({ ok: true, stats: recentStats, seenSize: seen.size });
+    return true;
+  }
+  if (msg && msg.type === "test_connection") {
+    getSettings().then(async (settings) => {
+      try {
+        await postFire(settings.serverUrl, {
+          text: "Slido → Danmu connected ✓",
+          fingerprint: "slido-extension",
+        });
+        sendResponse({ ok: true });
+      } catch (err) {
+        sendResponse({ ok: false, error: String(err.message || err) });
+      }
+    });
+    return true;
+  }
+});

--- a/slido-extension/background.js
+++ b/slido-extension/background.js
@@ -13,6 +13,7 @@ const DEFAULTS = {
   opacity: null,
   size: null,
   speed: null,
+  fireToken: "",         // X-Fire-Token — bypasses public rate limits + captcha
 };
 
 const seen = new Map();        // key -> timestamp
@@ -65,11 +66,13 @@ function buildPayload(text, settings) {
   return payload;
 }
 
-async function postFire(serverUrl, payload) {
+async function postFire(serverUrl, payload, fireToken) {
   const url = serverUrl.replace(/\/+$/, "") + "/fire";
+  const headers = { "Content-Type": "application/json" };
+  if (fireToken) headers["X-Fire-Token"] = fireToken;
   const resp = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify(payload),
     // credentials intentionally omitted: /fire is public, no cookies needed.
   });
@@ -119,7 +122,7 @@ async function handleCandidates(candidates) {
     }
 
     try {
-      await postFire(settings.serverUrl, payload);
+      await postFire(settings.serverUrl, payload, settings.fireToken);
       recentStats.forwarded++;
     } catch (err) {
       recentStats.errors++;
@@ -144,10 +147,11 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg && msg.type === "test_connection") {
     getSettings().then(async (settings) => {
       try {
-        await postFire(settings.serverUrl, {
-          text: "Slido → Danmu connected ✓",
-          fingerprint: "slido-extension",
-        });
+        await postFire(
+          settings.serverUrl,
+          { text: "Slido → Danmu connected ✓", fingerprint: "slido-extension" },
+          settings.fireToken,
+        );
         sendResponse({ ok: true });
       } catch (err) {
         sendResponse({ ok: false, error: String(err.message || err) });

--- a/slido-extension/content.js
+++ b/slido-extension/content.js
@@ -1,0 +1,29 @@
+// Content script: injects inject.js into the page's main world, then
+// relays postMessage events from the page to the background worker.
+(function () {
+  try {
+    const s = document.createElement("script");
+    s.src = chrome.runtime.getURL("inject.js");
+    s.async = false;
+    (document.head || document.documentElement).appendChild(s);
+    s.addEventListener("load", () => s.remove());
+  } catch (err) {
+    console.debug("[slido-danmu] inject failed", err);
+  }
+
+  window.addEventListener("message", (event) => {
+    if (event.source !== window) return;
+    const data = event.data;
+    if (!data || data.__slido_danmu__ !== true) return;
+    if (data.channel !== "SLIDO_DANMU_EVENT") return;
+    try {
+      chrome.runtime.sendMessage({
+        type: "slido_candidates",
+        candidates: data.candidates || [],
+        meta: data.meta || {},
+      });
+    } catch (err) {
+      // Extension context may be invalidated during reload; ignore.
+    }
+  });
+})();

--- a/slido-extension/inject.js
+++ b/slido-extension/inject.js
@@ -1,0 +1,171 @@
+// Injected into the PAGE (MAIN world) so we can hook window.fetch,
+// XMLHttpRequest, and WebSocket — content scripts live in an isolated
+// world and can't see page-level network activity.
+//
+// Strategy: wrap each transport. When a response/message looks like it
+// comes from Slido's API, extract candidate text fields and postMessage
+// to the content script (which relays to the background worker).
+(function () {
+  if (window.__SLIDO_DANMU_HOOKED__) return;
+  window.__SLIDO_DANMU_HOOKED__ = true;
+
+  const TAG = "[slido-danmu]";
+  const CHANNEL = "SLIDO_DANMU_EVENT";
+
+  function looksLikeSlidoUrl(url) {
+    if (!url || typeof url !== "string") return false;
+    return /(^|\/\/)([a-z0-9-]+\.)?(sli\.do|slido\.com)\//i.test(url);
+  }
+
+  // Fields we commonly see in Slido API payloads. We walk objects
+  // recursively so schema drift (v0.1 → v2 etc.) doesn't break us.
+  const TEXT_FIELDS = new Set([
+    "text",
+    "body",
+    "content",
+    "question",
+    "message",
+    "answer",
+    "title",
+  ]);
+  const AUTHOR_FIELDS = new Set([
+    "author_name",
+    "authorName",
+    "nickname",
+    "user_name",
+    "userName",
+    "display_name",
+    "displayName",
+    "name",
+  ]);
+  const ID_FIELDS = new Set(["id", "uuid", "message_id", "question_id"]);
+
+  function extractCandidates(payload, out, depth) {
+    if (!payload || depth > 6) return;
+    if (Array.isArray(payload)) {
+      for (const item of payload) extractCandidates(item, out, depth + 1);
+      return;
+    }
+    if (typeof payload !== "object") return;
+
+    let text = null;
+    let author = null;
+    let id = null;
+    for (const [k, v] of Object.entries(payload)) {
+      if (typeof v === "string" && v.trim()) {
+        if (!text && TEXT_FIELDS.has(k)) text = v;
+        else if (!author && AUTHOR_FIELDS.has(k)) author = v;
+        else if (!id && ID_FIELDS.has(k)) id = v;
+      }
+    }
+    if (text) {
+      out.push({ text, author, id });
+    }
+    for (const v of Object.values(payload)) {
+      if (v && typeof v === "object") extractCandidates(v, out, depth + 1);
+    }
+  }
+
+  function emit(candidates, meta) {
+    if (!candidates.length) return;
+    window.postMessage(
+      {
+        __slido_danmu__: true,
+        channel: CHANNEL,
+        candidates,
+        meta,
+      },
+      window.location.origin,
+    );
+  }
+
+  function tryExtractFromText(text, meta) {
+    if (!text) return;
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      return;
+    }
+    const out = [];
+    extractCandidates(parsed, out, 0);
+    emit(out, meta);
+  }
+
+  // --- fetch hook ---
+  const origFetch = window.fetch;
+  if (typeof origFetch === "function") {
+    window.fetch = async function patchedFetch(input, init) {
+      const resp = await origFetch.apply(this, arguments);
+      try {
+        const url = typeof input === "string" ? input : input?.url;
+        if (looksLikeSlidoUrl(url) && resp && resp.ok) {
+          const cloned = resp.clone();
+          cloned.text().then(
+            (body) =>
+              tryExtractFromText(body, { transport: "fetch", url }),
+            () => {},
+          );
+        }
+      } catch (err) {
+        console.debug(TAG, "fetch hook error", err);
+      }
+      return resp;
+    };
+  }
+
+  // --- XHR hook ---
+  const OrigXHR = window.XMLHttpRequest;
+  if (OrigXHR) {
+    const origOpen = OrigXHR.prototype.open;
+    const origSend = OrigXHR.prototype.send;
+    OrigXHR.prototype.open = function (method, url) {
+      this.__slido_url__ = url;
+      return origOpen.apply(this, arguments);
+    };
+    OrigXHR.prototype.send = function () {
+      this.addEventListener("load", () => {
+        try {
+          const url = this.__slido_url__;
+          if (!looksLikeSlidoUrl(url)) return;
+          const ctype = this.getResponseHeader("content-type") || "";
+          if (!/json|text/.test(ctype)) return;
+          tryExtractFromText(this.responseText, { transport: "xhr", url });
+        } catch (err) {
+          console.debug(TAG, "xhr hook error", err);
+        }
+      });
+      return origSend.apply(this, arguments);
+    };
+  }
+
+  // --- WebSocket hook ---
+  const OrigWS = window.WebSocket;
+  if (OrigWS) {
+    function PatchedWS(url, protocols) {
+      const ws = protocols !== undefined
+        ? new OrigWS(url, protocols)
+        : new OrigWS(url);
+      if (looksLikeSlidoUrl(url)) {
+        ws.addEventListener("message", (ev) => {
+          try {
+            if (typeof ev.data === "string") {
+              tryExtractFromText(ev.data, { transport: "ws", url });
+            }
+          } catch (err) {
+            console.debug(TAG, "ws hook error", err);
+          }
+        });
+      }
+      return ws;
+    }
+    PatchedWS.prototype = OrigWS.prototype;
+    PatchedWS.CONNECTING = OrigWS.CONNECTING;
+    PatchedWS.OPEN = OrigWS.OPEN;
+    PatchedWS.CLOSING = OrigWS.CLOSING;
+    PatchedWS.CLOSED = OrigWS.CLOSED;
+    window.WebSocket = PatchedWS;
+  }
+
+  console.info(TAG, "hooks installed");
+})();

--- a/slido-extension/manifest.json
+++ b/slido-extension/manifest.json
@@ -1,0 +1,46 @@
+{
+  "manifest_version": 3,
+  "name": "Slido → Danmu Bridge",
+  "version": "0.1.0",
+  "description": "Forward Slido questions/polls/messages to a local danmu-desktop server as danmu.",
+  "permissions": ["storage", "scripting"],
+  "host_permissions": [
+    "https://app.sli.do/*",
+    "https://*.sli.do/*",
+    "https://*.slido.com/*",
+    "http://localhost/*",
+    "http://127.0.0.1/*",
+    "http://*/*",
+    "https://*/*"
+  ],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://app.sli.do/*",
+        "https://*.sli.do/*",
+        "https://*.slido.com/*"
+      ],
+      "js": ["content.js"],
+      "run_at": "document_start",
+      "all_frames": true
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["inject.js"],
+      "matches": [
+        "https://app.sli.do/*",
+        "https://*.sli.do/*",
+        "https://*.slido.com/*"
+      ]
+    }
+  ],
+  "action": {
+    "default_title": "Slido → Danmu",
+    "default_popup": "popup.html"
+  }
+}

--- a/slido-extension/manifest.json
+++ b/slido-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Slido → Danmu Bridge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Forward Slido questions/polls/messages to a local danmu-desktop server as danmu.",
   "permissions": ["storage", "scripting"],
   "host_permissions": [

--- a/slido-extension/popup.html
+++ b/slido-extension/popup.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self'; style-src 'self' 'unsafe-inline';" />
+    <title>Slido → Danmu</title>
+    <style>
+      :root { color-scheme: dark; }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #0f1117;
+        color: #e8e8ef;
+        margin: 0;
+        padding: 12px 14px;
+        width: 320px;
+      }
+      h1 { font-size: 14px; margin: 0 0 10px; letter-spacing: .3px; }
+      label { display: block; font-size: 12px; margin: 10px 0 4px; color: #a6a6b8; }
+      input[type="text"], input[type="number"], select {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 6px 8px;
+        background: #1a1d27;
+        border: 1px solid #2a2e3c;
+        border-radius: 4px;
+        color: #e8e8ef;
+        font-size: 12px;
+      }
+      .row { display: flex; gap: 8px; align-items: center; }
+      .row > * { flex: 1; }
+      .toggle { display: flex; align-items: center; gap: 8px; margin: 4px 0; }
+      button {
+        padding: 6px 10px;
+        background: #38bdf8;
+        border: 0;
+        border-radius: 4px;
+        color: #0b1020;
+        font-weight: 600;
+        cursor: pointer;
+        font-size: 12px;
+      }
+      button.secondary { background: #2a2e3c; color: #e8e8ef; }
+      button:disabled { opacity: .5; cursor: not-allowed; }
+      .actions { display: flex; gap: 8px; margin-top: 12px; }
+      .status {
+        font-size: 11px;
+        color: #a6a6b8;
+        margin-top: 10px;
+        padding: 6px 8px;
+        border: 1px dashed #2a2e3c;
+        border-radius: 4px;
+        min-height: 14px;
+      }
+      .status.ok { color: #5fe3a1; border-color: #1e3a2b; }
+      .status.err { color: #ff8585; border-color: #3a1e1e; }
+      small { color: #6d6d7d; }
+    </style>
+  </head>
+  <body>
+    <h1>Slido → Danmu</h1>
+
+    <div class="toggle">
+      <input type="checkbox" id="enabled" />
+      <label for="enabled" style="margin:0;">Enabled</label>
+    </div>
+
+    <label for="serverUrl">Server URL</label>
+    <input type="text" id="serverUrl" placeholder="http://localhost:4000" />
+
+    <label for="mode">Mode</label>
+    <select id="mode">
+      <option value="live">Live (POST /fire)</option>
+      <option value="dry-run">Dry run (console only)</option>
+    </select>
+
+    <div class="row">
+      <div>
+        <label for="minIntervalMs">Min interval (ms)</label>
+        <input type="number" id="minIntervalMs" min="0" max="10000" step="100" />
+      </div>
+      <div>
+        <label for="maxTextLen">Max text len</label>
+        <input type="number" id="maxTextLen" min="10" max="100" step="1" />
+      </div>
+    </div>
+
+    <div class="toggle" style="margin-top:8px;">
+      <input type="checkbox" id="includeAuthor" />
+      <label for="includeAuthor" style="margin:0;">Prefix author name</label>
+    </div>
+
+    <div class="actions">
+      <button id="save">Save</button>
+      <button id="test" class="secondary">Test /fire</button>
+    </div>
+
+    <div id="status" class="status">—</div>
+
+    <p><small>Open a Slido event page, then check DevTools console
+      (on that tab) for <code>[slido-danmu]</code> hook logs.</small></p>
+
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/slido-extension/popup.html
+++ b/slido-extension/popup.html
@@ -68,6 +68,11 @@
     <label for="serverUrl">Server URL</label>
     <input type="text" id="serverUrl" placeholder="http://localhost:4000" />
 
+    <label for="fireToken">Fire Token (X-Fire-Token)
+      <small>— bypass public rate limit + captcha</small>
+    </label>
+    <input type="text" id="fireToken" placeholder="(optional)" autocomplete="off" />
+
     <label for="mode">Mode</label>
     <select id="mode">
       <option value="live">Live (POST /fire)</option>

--- a/slido-extension/popup.js
+++ b/slido-extension/popup.js
@@ -5,6 +5,7 @@ const DEFAULTS = {
   includeAuthor: true,
   minIntervalMs: 800,
   maxTextLen: 100,
+  fireToken: "",
 };
 
 const $ = (id) => document.getElementById(id);
@@ -20,6 +21,7 @@ async function load() {
   const s = { ...DEFAULTS, ...(stored.settings || {}) };
   $("enabled").checked = !!s.enabled;
   $("serverUrl").value = s.serverUrl;
+  $("fireToken").value = s.fireToken || "";
   $("mode").value = s.mode;
   $("includeAuthor").checked = !!s.includeAuthor;
   $("minIntervalMs").value = s.minIntervalMs;
@@ -43,6 +45,7 @@ async function save() {
   const settings = {
     enabled: $("enabled").checked,
     serverUrl: $("serverUrl").value.trim() || DEFAULTS.serverUrl,
+    fireToken: $("fireToken").value.trim(),
     mode: $("mode").value,
     includeAuthor: $("includeAuthor").checked,
     minIntervalMs: Math.max(0, parseInt($("minIntervalMs").value, 10) || 0),

--- a/slido-extension/popup.js
+++ b/slido-extension/popup.js
@@ -1,0 +1,77 @@
+const DEFAULTS = {
+  enabled: true,
+  serverUrl: "http://localhost:4000",
+  mode: "live",
+  includeAuthor: true,
+  minIntervalMs: 800,
+  maxTextLen: 100,
+};
+
+const $ = (id) => document.getElementById(id);
+const statusEl = $("status");
+
+function setStatus(msg, kind) {
+  statusEl.textContent = msg;
+  statusEl.className = "status" + (kind ? " " + kind : "");
+}
+
+async function load() {
+  const stored = await chrome.storage.local.get(["settings"]);
+  const s = { ...DEFAULTS, ...(stored.settings || {}) };
+  $("enabled").checked = !!s.enabled;
+  $("serverUrl").value = s.serverUrl;
+  $("mode").value = s.mode;
+  $("includeAuthor").checked = !!s.includeAuthor;
+  $("minIntervalMs").value = s.minIntervalMs;
+  $("maxTextLen").value = s.maxTextLen;
+
+  try {
+    const res = await chrome.runtime.sendMessage({ type: "get_stats" });
+    if (res?.ok) {
+      const { forwarded, skipped, errors, lastError } = res.stats;
+      setStatus(
+        `forwarded ${forwarded} · skipped ${skipped} · errors ${errors}` +
+          (lastError ? ` · ${lastError}` : ""),
+      );
+    }
+  } catch {
+    // Service worker might be asleep; no stats yet.
+  }
+}
+
+async function save() {
+  const settings = {
+    enabled: $("enabled").checked,
+    serverUrl: $("serverUrl").value.trim() || DEFAULTS.serverUrl,
+    mode: $("mode").value,
+    includeAuthor: $("includeAuthor").checked,
+    minIntervalMs: Math.max(0, parseInt($("minIntervalMs").value, 10) || 0),
+    maxTextLen: Math.min(
+      100,
+      Math.max(10, parseInt($("maxTextLen").value, 10) || 100),
+    ),
+  };
+  await chrome.storage.local.set({ settings });
+  setStatus("Saved.", "ok");
+}
+
+async function testFire() {
+  const btn = $("test");
+  btn.disabled = true;
+  setStatus("Sending…");
+  try {
+    const res = await chrome.runtime.sendMessage({ type: "test_connection" });
+    if (res?.ok) setStatus("Connected — a test danmu should appear on the overlay.", "ok");
+    else setStatus(`Failed: ${res?.error || "unknown error"}`, "err");
+  } catch (err) {
+    setStatus(`Failed: ${err.message || err}`, "err");
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  load();
+  $("save").addEventListener("click", save);
+  $("test").addEventListener("click", testFire);
+});


### PR DESCRIPTION
## Summary

Four-layer anti-abuse defense for the public `/fire` endpoint, motivated by
opening the server to WAN for real events where a single per-IP limit doesn't
stop IP-rotating spammers or distributed floods. Plus a new Slido → Danmu
browser extension (v0.2.0) that can talk to the admin fast-lane.

- **Per-fingerprint rate limit** (`FIRE_FINGERPRINT_RATE_LIMIT`, default 30/60s) — catches attackers rotating IPs via mobile hotspot / residential proxies.
- **Global rate limit ceiling** (`GLOBAL_FIRE_RATE_LIMIT`, off by default) — cross-client cap for distributed flood scenarios.
- **Admin fast-lane** (`X-Fire-Token` header → `FIRE_ADMIN_TOKEN`) — bypasses public per-IP / per-fingerprint / global limits and captcha, but has its own ceiling (`FIRE_ADMIN_RATE_LIMIT`, default 200/60s) so a runaway extension can't DoS itself. Timing-safe compare via `secrets.compare_digest`.
- **Captcha gate** (`CAPTCHA_PROVIDER=turnstile|hcaptcha`) — server-side `siteverify` via `urllib.request`. Fails open on missing secret (logged) so a typo doesn't brick the server.
- **Slido extension v0.2.0** — popup has a new **Fire Token** field; `background.js postFire()` now forwards it as `X-Fire-Token`.

### Wiring

`routes/api.py::fire` dropped the `@rate_limit("fire")` decorator and now calls
`enforce_fire_rate_limits(fingerprint, is_admin)` inline. Added
`except HTTPException: raise` before the broad `except Exception` so
`abort(429)` propagates correctly instead of getting swallowed into 500.

### Scope boundary

Server + extension only. **Zero UI/UX changes** in the main app
(`server/templates/`, `server/static/css/`, `server/static/js/`,
`danmu-desktop/`). v5.0.0 design-v2 territory is untouched.

Server-only release — `danmu-desktop/package.json` stays at 4.9.0 so
`build.yml` doesn't trigger Electron binary builds.

## Test plan

- [x] `test_fire_abuse_protection.py` — 12 new tests covering admin-bypass, token-mismatch-fallback, admin-ceiling, no-token-configured, fingerprint-catches-IP-rotation, fingerprint-0-disables, global-trips-across-IPs, global-admin-bypasses, captcha-rejects, captcha-approves, captcha-admin-skips, captcha-disabled-default
- [x] Full suite: 803 passed, 3 skipped (was 791)
- [x] Rebased on latest main (includes `9d81ce5` package.json sync commit)
- [ ] Manual: verify real Turnstile token end-to-end on a staging deploy before enabling `CAPTCHA_PROVIDER` in prod
- [ ] Manual: verify Slido extension popup field round-trips and `X-Fire-Token` shows up in request headers

Tags: `v4.9.1`, `slido-ext-v0.1.0`, `slido-ext-v0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)