### PR TITLE
Clarify portable release documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@
 
 ## [Unreleased]
 
-(no items pending)
+### 變更 / Changed
+
+- Release docs now match the portable-only desktop packaging policy: Windows is
+  documented as a portable x64 `.exe`, macOS as an arm64 `.zip`, and Linux as
+  AppImage / `.deb`.
+- Windows updater metadata remains unpublished while the Windows release channel
+  stays portable-only; macOS update metadata continues to target the ZIP package.
 
 ## [5.3.1] - 2026-05-20
 

--- a/README-CH.md
+++ b/README-CH.md
@@ -15,8 +15,10 @@
 1. Danmu-Desktop
    - 客戶端應用程式，在您的電腦上運行以顯示彈幕
    - 支援 Windows、MacOS 和 Linux
-   - 提供安裝版和可攜式版本
-   - 從 GitHub Releases 自動更新
+   - 發布為可攜式桌面套件：Windows portable x64 `.exe`、macOS arm64
+     `.zip`，以及 Linux AppImage / `.deb`
+   - Windows 維持 portable-only 時不發布更新 metadata；macOS 更新 metadata
+     指向 ZIP package
 
 ![img](img/client.png)
 ![img](img/client%20start%20effect.png)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ This project is divided into two parts:
 1. Danmu-Desktop
    - Client-side application that runs on your computer to display danmu
    - Supports Windows, MacOS, and Linux
-   - Available as both installer and portable version
-   - Auto-update from GitHub Releases
+   - Published as a portable desktop package: Windows portable x64 `.exe`,
+     macOS arm64 `.zip`, plus Linux AppImage / `.deb`
+   - Windows updater metadata is not published while the Windows channel stays
+     portable-only; macOS update metadata targets the ZIP package
 
 ![img](img/client.png)
 ![img](img/client%20start%20effect.png)

--- a/server/tests/test_ci_workflows.py
+++ b/server/tests/test_ci_workflows.py
@@ -125,6 +125,24 @@ def test_deployment_docs_present_scenario_based_setup_choices():
             assert text in body, f"{rel} should document setup scenario: {text}"
 
 
+def test_release_docs_do_not_advertise_installers_or_windows_updater_metadata():
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    readme_ch = (REPO_ROOT / "README-CH.md").read_text(encoding="utf-8")
+    changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    assert "Available as both installer and portable version" not in readme
+    assert "Auto-update from GitHub Releases" not in readme
+    assert "portable desktop package" in readme
+    assert "Windows updater metadata is not published" in readme
+
+    assert "可攜式桌面套件" in readme_ch
+    assert "不發布更新 metadata" in readme_ch
+
+    assert "## [Unreleased]\n\n(no items pending)" not in changelog
+    assert "portable-only desktop packaging policy" in changelog
+    assert "Windows updater metadata remains unpublished" in changelog
+
+
 def test_obsolete_desktop_compose_override_is_removed():
     assert not (REPO_ROOT / "docker-compose.desktop.yml").exists()
 


### PR DESCRIPTION
## Summary
- Update README release wording to match portable-only desktop packages.
- Clarify Windows updater metadata remains unpublished while Windows stays portable-only.
- Add a CI guard to prevent installer/updater release claims from coming back.

## Test Plan
- [x] PYTHONPATH=.. uv run --group dev pytest tests/test_ci_workflows.py::test_release_docs_do_not_advertise_installers_or_windows_updater_metadata -q
- [x] PYTHONPATH=.. uv run --group dev pytest tests/test_ci_workflows.py -q
- [x] uv run --with pre-commit --with pyyaml pre-commit run --all-files
- [x] git diff --check