### PR TITLE
Guard release metadata documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   AppImage / `.deb`.
 - Windows updater metadata remains unpublished while the Windows release channel
   stays portable-only; macOS update metadata continues to target the ZIP package.
+- Release workflow and feature inventory docs now use the same policy wording,
+  including macOS ZIP updater metadata, Windows portable-only output, and no
+  desktop first-run gate.
 
 ## [5.3.1] - 2026-05-20
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,10 @@ Every other setting ships a safe default; `.env.example` shows them all.
 
 - Workflow `.github/workflows/docker-build.yml` builds and tests the server image on each PR/push.
 - Workflow `.github/workflows/test.yml` runs Python tests with coverage reporting and `pip-audit` for CVE scanning.
-- Workflow `.github/workflows/build.yml` builds Electron app for Windows, macOS, and Linux on version bump, creating GitHub Releases with auto-update metadata.
+- Workflow `.github/workflows/build.yml` builds Electron app for Windows,
+  macOS, and Linux on version bump, then publishes GitHub Releases with
+  portable desktop artifacts. macOS ZIP updater metadata is published; Windows
+  updater metadata stays unpublished while Windows remains portable-only.
 - Set GitHub secrets `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` (Docker Hub access token) to auto-publish `DOCKERHUB_USERNAME/danmu-server:latest` and a commit-SHA tag whenever `main` is updated.
 
 ## Testing & Coverage

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -320,13 +320,19 @@ Render-only. No user input. Spawned by the main window.
 ### 3. Main process + tray
 
 - Tray icon + context menu (status snapshot / show control window / About / Quit)
-- Auto-updater via `electron-updater` — checks GitHub Releases on startup (10s delay) and every 4h
+- Auto-updater UX via `electron-updater` — checks GitHub Releases on startup
+  (10s delay) and every 4h where platform updater metadata is published.
+  Current policy publishes macOS ZIP metadata only; Windows updater metadata is
+  intentionally unpublished while Windows remains portable-only.
 - About window (`about.html`) — version + GitHub link
 - IPC surface (preload bridge) — see channels in [ipc-handlers.js](../danmu-desktop/main-modules/ipc-handlers.js); do not add new channels without extending preload
 
 ### 4. Packaging
 
-Electron-builder produces: Windows NSIS + portable, macOS .dmg, Linux AppImage + .deb. Auto-update publishes to GitHub Releases for this repo.
+Electron-builder produces portable-only release artifacts: Windows portable x64
+`.exe`, macOS arm64 `.zip`, and Linux AppImage + `.deb`. GitHub Releases publish
+macOS ZIP updater metadata; Windows updater metadata is intentionally
+unpublished while Windows remains portable-only.
 
 ---
 
@@ -335,7 +341,7 @@ Electron-builder produces: Windows NSIS + portable, macOS .dmg, Linux AppImage +
 These are the canonical flows. Designs should cover all of them, and **only** these.
 
 ### Scenario A — Streamer preparing to go live (v5.0.0)
-1. Launch desktop app → first-run gate prompts host/port → "Test connection" runs `wss://${host}:${port}/ws` against the configured server
+1. Launch desktop app → Connection tab accepts host/port → "Test connection" runs `wss://${host}:${port}/ws` against the configured server
 2. Pick display in the Overlay tab → click `開啟 Overlay` → overlay child window spawns on chosen display
 3. Open `/admin/` (browser, not in client) → pick theme → adjust default Color / Speed / FontSize → activate effects
 4. Send a real danmu from `/` (or another viewer) to confirm rendering. **Test danmu UI no longer in client — that moved to admin.**

--- a/server/tests/test_ci_workflows.py
+++ b/server/tests/test_ci_workflows.py
@@ -128,15 +128,26 @@ def test_deployment_docs_present_scenario_based_setup_choices():
 def test_release_docs_do_not_advertise_installers_or_windows_updater_metadata():
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
     readme_ch = (REPO_ROOT / "README-CH.md").read_text(encoding="utf-8")
+    features = (REPO_ROOT / "docs" / "FEATURES.md").read_text(encoding="utf-8")
     changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
 
     assert "Available as both installer and portable version" not in readme
     assert "Auto-update from GitHub Releases" not in readme
+    assert "creating GitHub Releases with auto-update metadata" not in readme
     assert "portable desktop package" in readme
     assert "Windows updater metadata is not published" in readme
 
     assert "可攜式桌面套件" in readme_ch
     assert "不發布更新 metadata" in readme_ch
+
+    assert "Windows NSIS + portable" not in features
+    assert "macOS .dmg" not in features
+    assert "first-run gate prompts host/port" not in features
+    assert "Windows portable x64" in features
+    assert "`.exe`" in features
+    assert "macOS arm64 `.zip`" in features
+    assert "Windows updater metadata is" in features
+    assert "intentionally unpublished" in features
 
     assert "## [Unreleased]\n\n(no items pending)" not in changelog
     assert "portable-only desktop packaging policy" in changelog


### PR DESCRIPTION
## Summary
- Align README CI/CD wording with portable desktop artifacts and macOS ZIP updater metadata.
- Update feature inventory to remove Windows NSIS, macOS DMG, and desktop first-run gate language.
- Extend CI guard coverage so these stale release metadata docs do not come back.

## Test Plan
- [x] PYTHONPATH=.. uv run --group dev pytest tests/test_ci_workflows.py::test_release_docs_do_not_advertise_installers_or_windows_updater_metadata -q
- [x] PYTHONPATH=.. uv run --group dev pytest tests/test_ci_workflows.py -q
- [x] uv run --with pre-commit --with pyyaml pre-commit run --all-files
- [x] git diff --check