### PR TITLE
refactor(css): Batch 1 — explicit transitions + tabular figures (UIUX)

### DIFF
--- a/server/static/css/style.css
+++ b/server/static/css/style.css
@@ -5791,7 +5791,7 @@ body.stream-mode .admin-hero .admin-summary-grid {
   border: 1px solid transparent;
   border-radius: var(--radius-md-sm);
   cursor: pointer;
-  transition: all var(--motion-fast) ease;
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease, color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, transform var(--motion-fast) ease;
 }
 .admin-ui-tab:hover { color: var(--color-text-strong); }
 .admin-ui-tab.is-active {
@@ -6414,7 +6414,7 @@ body[data-history-tab="replay"] #history-v2-section { display: none !important; 
   font-family: var(--font-mono);
   font-size: 11px; font-weight: 700;
   color: var(--color-text-muted);
-  transition: all var(--motion-normal) ease;
+  transition: background-color var(--motion-normal) ease, border-color var(--motion-normal) ease, color var(--motion-normal) ease, box-shadow var(--motion-normal) ease, transform var(--motion-normal) ease;
 }
 .admin-setup-step .lbl {
   font-size: 12px;
@@ -6508,7 +6508,7 @@ body[data-history-tab="replay"] #history-v2-section { display: none !important; 
   border-radius: var(--radius-md-sm);
   background: var(--color-bg);
   cursor: pointer;
-  transition: all var(--motion-fast) ease;
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease, color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, transform var(--motion-fast) ease;
 }
 .admin-setup-theme-card:hover {
   border-color: rgba(56, 189, 248, 0.55);
@@ -6576,7 +6576,7 @@ body[data-history-tab="replay"] #history-v2-section { display: none !important; 
   border-radius: var(--radius-md-sm);
   background: var(--color-bg);
   cursor: pointer;
-  transition: all var(--motion-fast) ease;
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease, color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, transform var(--motion-fast) ease;
 }
 .admin-setup-lang-card:hover { border-color: rgba(56, 189, 248, 0.45); }
 .admin-setup-lang-card.is-selected {
@@ -6753,7 +6753,7 @@ body[data-history-tab="replay"] #history-v2-section { display: none !important; 
   color: var(--color-text-muted);
   cursor: pointer;
   letter-spacing: 0.3px;
-  transition: all var(--motion-fast) ease;
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease, color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, transform var(--motion-fast) ease;
 }
 .admin-setup-file-btn:hover {
   color: var(--color-primary);
@@ -6783,7 +6783,7 @@ body[data-history-tab="replay"] #history-v2-section { display: none !important; 
   color: var(--color-danger, #f87171);
   cursor: pointer;
   letter-spacing: 0.3px;
-  transition: all var(--motion-fast) ease;
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease, color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, transform var(--motion-fast) ease;
 }
 .admin-setup-logo-remove:hover {
   border-color: var(--color-danger, #f87171);
@@ -7170,7 +7170,7 @@ body[data-setup-wizard-open="1"] { overflow: hidden; }
   text-align: center;
   cursor: pointer;
   text-decoration: none;
-  transition: all var(--motion-fast) ease;
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease, color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, transform var(--motion-fast) ease;
 }
 .admin-pdd-action:hover {
   border-color: var(--color-primary);
@@ -9220,7 +9220,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
   cursor: pointer;
   font-family: var(--font-mono);
   font-size: 10px; letter-spacing: 0.4px;
-  transition: all var(--motion-fast) ease;
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease, color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, transform var(--motion-fast) ease;
 }
 .admin-msgd-nav .arrow { font-size: 11px; }
 .admin-msgd-nav + .admin-msgd-nav { margin-left: 0; }
@@ -9237,7 +9237,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
   border-radius: var(--radius-xs);
   cursor: pointer;
   font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.4px;
-  transition: all var(--motion-fast) ease;
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease, color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, transform var(--motion-fast) ease;
 }
 .admin-msgd-close .arrow { font-size: 11px; }
 .admin-msgd-close:hover { color: var(--color-text-strong); border-color: var(--color-primary); }
@@ -9330,7 +9330,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
   text-align: center;
   font-family: inherit;
   color: var(--color-text-strong);
-  transition: all var(--motion-fast) ease;
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease, color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, transform var(--motion-fast) ease;
 }
 .admin-msgd-actions button:disabled { opacity: 0.4; cursor: not-allowed; }
 .admin-msgd-actions button:hover:not(:disabled) {
@@ -9778,7 +9778,7 @@ body[data-message-drawer-open="1"] .admin-msgd-overlay { pointer-events: auto; }
   border-left: 3px solid;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all var(--motion-fast) ease;
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease, color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, transform var(--motion-fast) ease;
 }
 .admin-notif-item:hover {
   background: var(--hover-tint-weak);
@@ -10094,7 +10094,7 @@ body[data-message-drawer-open="1"] .admin-msgd-overlay { pointer-events: auto; }
 .admin-vc-toggle {
   font-family: var(--font-mono); font-size: 10px; letter-spacing: 1px;
   padding: 4px 10px; border-radius: var(--radius-xs); cursor: pointer; border: 1px solid;
-  transition: all var(--motion-fast) ease;
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease, color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, transform var(--motion-fast) ease;
 }
 .admin-vc-toggle.is-on {
   color: var(--color-primary);
@@ -11953,7 +11953,7 @@ body[data-message-drawer-open="1"] .admin-msgd-overlay { pointer-events: auto; }
   background: transparent;
   border: 1.5px solid var(--color-border);
   color: var(--color-text-muted);
-  transition: all var(--motion-fast) var(--ease-out, ease);
+  transition: background-color var(--motion-fast) var(--ease-out, ease), border-color var(--motion-fast) var(--ease-out, ease), color var(--motion-fast) var(--ease-out, ease), box-shadow var(--motion-fast) var(--ease-out, ease), transform var(--motion-fast) var(--ease-out, ease);
 }
 .admin-sd-ann-modal-lbl.is-active {
   border-color: var(--ann-color, #38bdf8);
@@ -12278,7 +12278,7 @@ body[data-message-drawer-open="1"] .admin-msgd-overlay { pointer-events: auto; }
   border: 1px solid var(--color-border, rgba(255,255,255,0.18));
   color: var(--color-text-muted);
   cursor: pointer;
-  transition: all var(--motion-fast) var(--ease-out, ease);
+  transition: background-color var(--motion-fast) var(--ease-out, ease), border-color var(--motion-fast) var(--ease-out, ease), color var(--motion-fast) var(--ease-out, ease), box-shadow var(--motion-fast) var(--ease-out, ease), transform var(--motion-fast) var(--ease-out, ease);
 }
 .admin-modbans-unban:not(:disabled):hover {
   border-color: var(--hud-crimson);
@@ -12489,7 +12489,7 @@ body[data-message-drawer-open="1"] .admin-msgd-overlay { pointer-events: auto; }
   background: transparent;
   color: var(--color-text-muted);
   cursor: pointer;
-  transition: all var(--motion-fast) var(--ease-out, ease);
+  transition: background-color var(--motion-fast) var(--ease-out, ease), border-color var(--motion-fast) var(--ease-out, ease), color var(--motion-fast) var(--ease-out, ease), box-shadow var(--motion-fast) var(--ease-out, ease), transform var(--motion-fast) var(--ease-out, ease);
 }
 .admin-modbans-modal-custom-unit.is-active {
   border-color: var(--color-primary);
@@ -12579,7 +12579,7 @@ body[data-message-drawer-open="1"] .admin-msgd-overlay { pointer-events: auto; }
   border: 1.5px solid var(--color-border);
   background: transparent;
   cursor: pointer;
-  transition: all var(--motion-fast) var(--ease-out, ease);
+  transition: background-color var(--motion-fast) var(--ease-out, ease), border-color var(--motion-fast) var(--ease-out, ease), color var(--motion-fast) var(--ease-out, ease), box-shadow var(--motion-fast) var(--ease-out, ease), transform var(--motion-fast) var(--ease-out, ease);
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -13582,7 +13582,7 @@ body.admin-pu-open { overflow: hidden; }
   border: 2px dashed var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   background: transparent;
   text-align: center;
-  transition: all var(--motion-fast) ease;
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease, color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, transform var(--motion-fast) ease;
   cursor: pointer;
 }
 

--- a/server/static/css/style.css
+++ b/server/static/css/style.css
@@ -56,10 +56,22 @@ body {
   --font-ui: "Noto Sans", "Noto Sans KR", system-ui, sans-serif;
 }
 
-/* Tabular figures — numbers align column-to-column in data displays */
+/* Tabular figures — numbers align column-to-column in data displays.
+   The [data-tabular] hook opts elements in explicitly; the [class*=…]
+   selectors below cover the recurring number-carrier naming across admin
+   modules (stat values, counts, metrics, percentages) so digits line up
+   without touching each module. tabular-nums is a no-op on non-numeric
+   text, so the broad class match is safe. */
 [data-tabular],
 .history-dashboard-value,
-.chart-label {
+.chart-label,
+[class*="-value"],
+[class*="-count"],
+[class*="-num"],
+[class*="-metric"],
+[class*="-pct"],
+[class*="-percent"],
+[class*="-stat-v"] {
   font-variant-numeric: tabular-nums;
 }
 

--- a/server/static/css/viewer-v2.css
+++ b/server/static/css/viewer-v2.css
@@ -2228,7 +2228,7 @@ body.viewer-body-v2:not(.is-dark) .viewer-nickname-inline-input {
   background: transparent;
   color: var(--color-text-muted);
   cursor: pointer;
-  transition: all var(--motion-fast) var(--ease-out, ease);
+  transition: background-color var(--motion-fast) var(--ease-out, ease), border-color var(--motion-fast) var(--ease-out, ease), color var(--motion-fast) var(--ease-out, ease), box-shadow var(--motion-fast) var(--ease-out, ease), transform var(--motion-fast) var(--ease-out, ease);
 }
 .viewer-mobile-sheet-seg.is-active {
   border-color: var(--color-primary);

--- a/shared/hud.css
+++ b/shared/hud.css
@@ -2834,7 +2834,7 @@ html[data-theme="dark"] .admin-body .hud-hero-title {
   background: transparent;
   color: var(--admin-text-dim, #94a3b8);
   cursor: pointer;
-  transition: all var(--motion-fast) ease;
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease, color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, transform var(--motion-fast) ease;
 }
 .admin-cmdk-chip:hover { color: var(--admin-text, #e2e8f0); }
 .admin-cmdk-chip.is-on {


### PR DESCRIPTION
UIUX 統一 **Batch 1** —— 從 9 源稽核導出的低風險快贏。詳見稽核報告 artifact。

## 1. `transition: all` → 顯式屬性清單（19 處）
`transition:all` 會連 layout 屬性（width/height/padding）都動、有 jank 風險，且違反 Vercel Web Interface Guidelines。19 處全是互動元件（tab/card/chip/nav/button/dropzone）。抽樣其 `:hover/.is-active/.selected` 確認只改 paint/compositor 屬性後，替換為 `background-color, border-color, color, box-shadow, transform`（保留原時長/easing）→ hover 動效不變、layout 不再被動畫。

## 2. `outline:none` 稽核 → **無需改（驗證後結論）**
稽核初報 42 個 `outline:none`。逐一驗證後確認**已正確處理**：`style.css` 有全域 `*:focus-visible { outline: 2px solid var(--color-primary) }` catch-all，加上 `.admin-app-shell input/select/textarea:focus` 的 border+ring——所有元件鍵盤 focus 都有可見指示。這是現代正確模式（`:focus` 去外框、`:focus-visible` 給外框），**假警報，不動 code**。

## 3. `tabular-nums` 涵蓋擴充
admin 大量 stat/count/metric/百分比數字未對齊。擴充既有 tabular-figures 規則，用 `[class*=…]` 涵蓋常見數字類命名。tabular-nums 對非數字無害。

## 驗證
- 抽樣 state 規則確認 transition 屬性集；`make lint-css` 綠；`npm run build:css` → tailwind.css 未受影響。
- outline:none 結論經 `*:focus-visible` 全域規則佐證。

Refs #120 · UIUX unification（Batch 1/4）

🤖 Generated with [Claude Code](https://claude.com/claude-code)