### PR TITLE
refactor(css): Batch 2a — consolidate theme-invariant rgba into tokens (UIUX)

### DIFF
--- a/server/static/css/overlay.css
+++ b/server/static/css/overlay.css
@@ -115,7 +115,7 @@ body {
   line-height: 1;
   filter:
     drop-shadow(0 10px 15px rgba(0, 0, 0, 0.45))
-    drop-shadow(0 4px 6px rgba(0, 0, 0, 0.3));
+    drop-shadow(0 4px 6px var(--shadow-base, rgba(0, 0, 0, 0.3)));
 }
 
 .overlay-idle-subtitle {

--- a/server/static/css/style.css
+++ b/server/static/css/style.css
@@ -5401,7 +5401,7 @@ body.stream-mode .admin-hero .admin-summary-grid {
   border-color: var(--color-primary);
   color: var(--color-primary);
   background: var(--hud-cyan-soft);
-  box-shadow: 0 0 6px rgba(56, 189, 248, 0.4);
+  box-shadow: 0 0 6px var(--glow-primary, rgba(56, 189, 248, 0.4));
 }
 .admin-konami-hud-progress {
   margin-top: 6px;
@@ -5946,7 +5946,7 @@ body[data-history-tab="replay"] #history-v2-section { display: none !important; 
   font-family: inherit;
 }
 .histv2-chip:hover, .histv2-toggle:hover {
-  border-color: rgba(56, 189, 248, 0.4);
+  border-color: var(--glow-primary, rgba(56, 189, 248, 0.4));
 }
 .histv2-chip.is-active {
   background: var(--hud-cyan-soft);
@@ -5989,7 +5989,7 @@ body[data-history-tab="replay"] #history-v2-section { display: none !important; 
   text-align: left;
   font-family: inherit;
 }
-.histv2-fmt:hover { border-color: rgba(56, 189, 248, 0.4); }
+.histv2-fmt:hover { border-color: var(--glow-primary, rgba(56, 189, 248, 0.4)); }
 .histv2-fmt.is-selected {
   border-color: var(--color-primary);
 }
@@ -6903,7 +6903,7 @@ body[data-history-tab="replay"] #history-v2-section { display: none !important; 
   height: 16px;
   border-radius: 50%;
   background: #fff;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 1px 3px var(--shadow-base, rgba(0, 0, 0, 0.3));
 }
 
 .admin-setup-toggle-switch.is-on {
@@ -7480,7 +7480,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
   background: var(--hud-bg1);
   border: 1px solid rgba(255, 77, 79, 0.21);
   border-radius: var(--radius-lg);
-  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.6);
+  box-shadow: 0 12px 48px var(--color-overlay, rgba(0, 0, 0, 0.6));
 }
 .admin-eoff__icon {
   width: 56px; height: 56px; margin: 0 auto;
@@ -8172,7 +8172,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
     border-top: 2px solid var(--color-primary);
     border-radius: var(--radius-xl) var(--radius-xl) 0 0;
     align-self: flex-end;
-    box-shadow: 0 -12px 48px rgba(0, 0, 0, 0.6) !important;
+    box-shadow: 0 -12px 48px var(--color-overlay, rgba(0, 0, 0, 0.6)) !important;
     animation: hud-mobile-sheet-up 220ms cubic-bezier(0.32, 1.4, 0.34, 1);
   }
   .admin-msgd-overlay { align-items: flex-end; }
@@ -8516,7 +8516,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
   color: var(--color-text-strong);
   border-radius: var(--radius-md); overflow: hidden;
   border: 1px solid rgba(251, 191, 36, 0.33);
-  box-shadow: 0 16px 64px rgba(0, 0, 0, 0.6);
+  box-shadow: 0 16px 64px var(--color-overlay, rgba(0, 0, 0, 0.6));
   animation: hud-modal-rise 200ms ease-out;
 }
 @keyframes hud-modal-rise {
@@ -9069,7 +9069,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
   color: var(--hud-text);
   border-radius: var(--radius-md); overflow: hidden;
   border: 1px solid rgba(255, 77, 79, 0.33);
-  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.6);
+  box-shadow: 0 24px 64px var(--color-overlay, rgba(0, 0, 0, 0.6));
   animation: msgd-slide-up 200ms ease-out;
 }
 @keyframes msgd-slide-up { from { transform: translateY(12px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
@@ -13214,7 +13214,7 @@ body[data-message-drawer-open="1"] .admin-msgd-overlay { pointer-events: auto; }
   height: 16px;
   border-radius: 50%;
   background: #fff;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 1px 3px var(--shadow-base, rgba(0, 0, 0, 0.3));
   transition: transform var(--motion-fast) ease;
 }
 

--- a/server/static/css/viewer-v2.css
+++ b/server/static/css/viewer-v2.css
@@ -270,7 +270,7 @@ body.viewer-body-v2:not(.is-dark) .viewer-hero-marquee {
   line-height: 1;
   filter:
     drop-shadow(0 10px 15px rgba(0, 0, 0, 0.45))
-    drop-shadow(0 4px 6px rgba(0, 0, 0, 0.3));
+    drop-shadow(0 4px 6px var(--shadow-base, rgba(0, 0, 0, 0.3)));
 }
 
 /* Light theme — design v4 brief 0518-v3 #3 fix (2026-05-18).
@@ -1701,7 +1701,7 @@ body.viewer-has-topstrip .viewer-topstrip {
   background: linear-gradient(
     180deg,
     rgba(248, 113, 113, 0.08) 0%,
-    rgba(15, 23, 42, 0.75) 100%
+    var(--color-bg-card, rgba(15, 23, 42, 0.75)) 100%
   );
 }
 .viewer-offline-lockup {
@@ -2047,7 +2047,7 @@ body[data-viewer-state] {
 .viewer-nickname-chip:hover,
 .viewer-nickname-chip[aria-expanded="true"] {
   background: rgba(56, 189, 248, 0.18);
-  border-color: rgba(56, 189, 248, 0.6);
+  border-color: var(--glow-primary-lg, rgba(56, 189, 248, 0.6));
 }
 
 /* Light theme — design v4 brief 0518-v3 #3 fix (2026-05-18).
@@ -2164,7 +2164,7 @@ body.viewer-body-v2:not(.is-dark) .viewer-nickname-inline-input {
   background: var(--hud-bg1);
   border-top: 2px solid var(--color-primary);
   border-radius: var(--radius-xl) var(--radius-xl) 0 0;
-  box-shadow: 0 -12px 48px rgba(0, 0, 0, 0.6);
+  box-shadow: 0 -12px 48px var(--color-overlay, rgba(0, 0, 0, 0.6));
   transform: translateY(100%);
   transition: transform var(--motion-normal, 180ms) var(--ease-out, ease);
   pointer-events: auto;
@@ -2358,7 +2358,7 @@ body.viewer-body-v2.is-dark .viewer-theme-chip-seg {
 .viewer-poll-dot.is-current {
   background: var(--color-primary);
   width: 20px;
-  box-shadow: 0 0 8px rgba(56, 189, 248, 0.5);
+  box-shadow: 0 0 8px var(--glow-primary-ring, rgba(56, 189, 248, 0.5));
 }
 
 /* Auto-mode timer bar — sits between options and dots. */

--- a/shared/hud.css
+++ b/shared/hud.css
@@ -271,7 +271,7 @@
   line-height: 1;
   filter:
     drop-shadow(0 10px 15px rgba(0, 0, 0, 0.45))
-    drop-shadow(0 4px 6px rgba(0, 0, 0, 0.3));
+    drop-shadow(0 4px 6px var(--shadow-base, rgba(0, 0, 0, 0.3)));
 }
 
 .hud-hero-title.is-hero {
@@ -284,7 +284,7 @@
 
 .hud-hero-title.is-medium {
   font-size: 2rem;
-  filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.3));
+  filter: drop-shadow(0 4px 6px var(--shadow-base, rgba(0, 0, 0, 0.3)));
 }
 
 /* D4 — the brand lockup's drop-shadow is tuned for the dark viewer / overlay
@@ -312,7 +312,7 @@
 html[data-theme="dark"] .admin-body .hud-hero-title {
   filter:
     drop-shadow(0 10px 15px rgba(0, 0, 0, 0.45))
-    drop-shadow(0 4px 6px rgba(0, 0, 0, 0.3));
+    drop-shadow(0 4px 6px var(--shadow-base, rgba(0, 0, 0, 0.3)));
 }
 
 /* HeroInline — compact sidebar / header variant. Bebas Neue at 1.5rem. */
@@ -2807,7 +2807,7 @@ html[data-theme="dark"] .admin-body .hud-hero-title {
   background: var(--admin-panel, #0b1220);
   border: 1px solid var(--admin-line, #1e293b);
   border-radius: 10px;
-  box-shadow: 0 20px 60px -10px rgba(0, 0, 0, 0.6),
+  box-shadow: 0 20px 60px -10px var(--color-overlay, rgba(0, 0, 0, 0.6)),
               0 0 0 1px rgba(56, 189, 248, 0.18);
   overflow: hidden;
   animation: admin-cmdk-slide 160ms ease-out;
@@ -2861,7 +2861,7 @@ html[data-theme="dark"] .admin-body .hud-hero-title {
   font-family: var(--font-mono);
   font-size: 11px;
   color: var(--color-primary);
-  border: 1px solid rgba(56, 189, 248, 0.4);
+  border: 1px solid var(--glow-primary, rgba(56, 189, 248, 0.4));
   border-radius: var(--radius-sm);
   padding: 2px 8px;
   letter-spacing: 1px;
@@ -3927,7 +3927,7 @@ html[data-theme="dark"] .admin-body .hud-hero-title {
   font-size: 42px;
   font-weight: 700;
   flex-shrink: 0;
-  box-shadow: 0 0 24px rgba(56, 189, 248, 0.4);
+  box-shadow: 0 0 24px var(--glow-primary, rgba(56, 189, 248, 0.4));
 }
 .admin-polls-results-winner .info { flex: 1; min-width: 0; }
 .admin-polls-results-winner .kicker {
@@ -4506,7 +4506,7 @@ html[data-theme="dark"] .admin-body .hud-hero-title {
 .admin-broadcast-bigdot {
   width: 56px; height: 56px; flex-shrink: 0;
   border-radius: 50%;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--color-overlay, rgba(0, 0, 0, 0.6));
   border: 2px solid rgba(125, 211, 252, 0.85);
   box-shadow: 0 0 24px rgba(125, 211, 252, 0.55);
   display: flex; align-items: center; justify-content: center;


### PR DESCRIPTION
UIUX 統一 **Batch 2a** —— 把裸 `rgba()` 收斂成 design token，只做**主題不變**的、真正零視覺變化的部分。

## 做了什麼（22 處）
裸 `rgba()` → `var(--token, <原 rgba>)`，只針對**主題不變 token**（`:root` 與所有 light/dark 覆寫值都相同）：
- `--shadow-base` ×7 · `--color-overlay` ×7 · `--glow-primary/-ring/-lg` ×7 · `--color-bg-card` ×1

保留原 rgba 當 fallback（符合本 repo 慣例），token 未載入時 fallback 到相同值 → **兩個主題都零視覺變化**。

## 刻意排除（73 處，另議）
匹配**主題可變** token 的裸 rgba（`--hud-cyan-line/-soft`、`--hud-line`、`--admin-line`、`--hover-tint-*`、`--color-border-strong`）**不在此 PR**。把固定字面換成主題感應 token 會改變另一個主題的呈現——那多半是「修 light 主題適配」的**視覺變更、需審視**，不能當機械替換盲做。列為後續 reviewed change。

## 為何 scope 從 95 縮到 22
初掃「精確等於某 token」有 95 個，但其中多數 token 是主題可變的。逐一核對 tokens.css 的 light/dark 覆寫後，只有 22 個對應主題不變 token → 這才是零風險可自動化的真實 scope。誠實勝過數字好看。

## 驗證
- 主題不變性由 tokens.css 的 `:root` / `[data-theme=light]` / `prefers-color-scheme:light` 三區塊比對得出。
- `npm run build:css` → tailwind.css 未受影響（token 名不與 tailwind theme key 衝突）。
- `make lint-css` 綠；腳本重跑冪等。

Refs #120 · UIUX unification（Batch 2a）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved theme consistency across overlays, HUD elements, dialogs, cards, controls, and viewer panels.
  * Updated shadows, borders, glows, gradients, and overlays to respond more consistently to active theme settings.
  * Preserved existing layouts and visual behavior with fallback styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->