### PR TITLE
refactor(css/ui): Batch 2b theme-variable rgba + rgba lint ratchet + ✕→SVG close icon (#120)

### DIFF
--- a/scripts/check-css-tokens.mjs
+++ b/scripts/check-css-tokens.mjs
@@ -19,6 +19,15 @@
  *               are NOT counted — they have no exact token, so flagging them
  *               would be noise. Element sizing (width/height/…) is excluded
  *               too — --space-* is a spacing semantic, not a dimension.
+ *   3. rgba   — bare rgb()/rgba() color literals that are NOT already the
+ *               fallback of a var(--token, rgba(...)) declaration. The folded
+ *               idiom var(--token, rgba(...)) is the *desired* end state (Batch
+ *               2a/2b, #120), so an rgba serving as a var() fallback does NOT
+ *               count — that means folding a bare literal into a token always
+ *               LOWERS this count (rewarding the retrofit), while a freshly
+ *               hardcoded rgba raises it (a regression). Like hex/gridPx this
+ *               does not force existing literals to zero; it locks in today's
+ *               count and only fails when a file grows.
  *
  * Design: this does NOT try to force the pre-existing values to zero in one
  * pass — a full sweep is out of scope for a lint gate (Issue #120 tracks the
@@ -126,17 +135,47 @@ function countGridPx(content) {
   return n;
 }
 
-function countFile(content) {
-  return { hex: countHexColors(content), gridPx: countGridPx(content) };
+// A bare rgb()/rgba() is a hardcoded color. One that appears as the fallback of
+// var(--token, rgba(...)) is already tokenized (the repo idiom) and must NOT
+// count — otherwise folding a literal into a token wouldn't lower the metric.
+// rgb()/rgba() args are plain numbers/percentages (no nested parens), so the
+// simple [^)]* body match is safe. Strip the folded idiom first, then tally what
+// remains. var(--a, var(--b, rgba(...))) nests the rgba one level deeper, so we
+// peel var(...) fallbacks repeatedly until the pass stops removing any.
+const VAR_FALLBACK_RGBA_RE = /var\(\s*--[\w-]+\s*,\s*rgba?\([^)]*\)\s*\)/gi;
+const BARE_RGBA_RE = /\brgba?\(/gi;
+
+function countBareRgba(content) {
+  let prev;
+  let src = content;
+  do {
+    prev = src;
+    src = src.replace(VAR_FALLBACK_RGBA_RE, "var(--tokenized)");
+  } while (src !== prev);
+  const matches = src.match(BARE_RGBA_RE);
+  return matches ? matches.length : 0;
 }
 
-// Baseline entries may be a legacy bare number (hex-only) or { hex, gridPx }.
-// Normalize to the object form; a legacy number grandfathers gridPx to
-// Infinity so the very first run before a --update migration can't fail on the
-// new metric.
+function countFile(content) {
+  return {
+    hex: countHexColors(content),
+    gridPx: countGridPx(content),
+    rgba: countBareRgba(content),
+  };
+}
+
+// Baseline entries may be a legacy bare number (hex-only) or
+// { hex, gridPx[, rgba] }. Normalize to the object form; any metric absent from
+// an older baseline is grandfathered to Infinity so the first run before an
+// --update migration can't fail on a newly-added metric.
 function normalizeBaselineEntry(entry) {
-  if (typeof entry === "number") return { hex: entry, gridPx: Infinity };
-  return { hex: entry?.hex ?? 0, gridPx: entry?.gridPx ?? Infinity };
+  if (typeof entry === "number")
+    return { hex: entry, gridPx: Infinity, rgba: Infinity };
+  return {
+    hex: entry?.hex ?? 0,
+    gridPx: entry?.gridPx ?? Infinity,
+    rgba: entry?.rgba ?? Infinity,
+  };
 }
 
 function relPath(p) {
@@ -189,7 +228,7 @@ function main() {
 
   for (const [file, count] of Object.entries(current)) {
     const before = normalizeBaselineEntry(baseline[file] ?? 0);
-    for (const metric of ["hex", "gridPx"]) {
+    for (const metric of ["hex", "gridPx", "rgba"]) {
       if (count[metric] > before[metric]) {
         regressions.push({
           file,
@@ -206,12 +245,14 @@ function main() {
   // actually contain something to flag — a brand-new file with zero of both
   // metrics is fine.
   const newFilesWithValues = Object.keys(current).filter(
-    (f) => !(f in baseline) && (current[f].hex > 0 || current[f].gridPx > 0),
+    (f) =>
+      !(f in baseline) &&
+      (current[f].hex > 0 || current[f].gridPx > 0 || current[f].rgba > 0),
   );
 
   if (regressions.length === 0 && newFilesWithValues.length === 0) {
     console.log(
-      `✓ check-css-tokens: no new hardcoded hex colors or token-able px (${Object.keys(current).length} CSS files checked against baseline)`,
+      `✓ check-css-tokens: no new hardcoded hex colors, token-able px, or bare rgba (${Object.keys(current).length} CSS files checked against baseline)`,
     );
     return;
   }
@@ -222,6 +263,7 @@ function main() {
   const label = {
     hex: "hex colors → use var(--color-...)",
     gridPx: "token-able px (font-size/spacing) → use var(--text-*/--space-*)",
+    rgba: "bare rgb()/rgba() → fold into var(--token, rgba(...))",
   };
   for (const r of regressions) {
     console.error(
@@ -230,7 +272,7 @@ function main() {
   }
   for (const f of newFilesWithValues) {
     console.error(
-      `  ${f}: new file with ${current[f].hex} hex / ${current[f].gridPx} token-able px not yet in baseline. Use tokens where possible, then run 'node scripts/check-css-tokens.mjs --update' to record the intentional baseline.`,
+      `  ${f}: new file with ${current[f].hex} hex / ${current[f].gridPx} token-able px / ${current[f].rgba} bare rgba not yet in baseline. Use tokens where possible, then run 'node scripts/check-css-tokens.mjs --update' to record the intentional baseline.`,
     );
   }
   console.error(

--- a/scripts/css-token-baseline.json
+++ b/scripts/css-token-baseline.json
@@ -1,38 +1,47 @@
 {
   "danmu-desktop/about.css": {
     "hex": 2,
-    "gridPx": 0
+    "gridPx": 0,
+    "rgba": 4
   },
   "danmu-desktop/child.css": {
     "hex": 13,
-    "gridPx": 4
+    "gridPx": 4,
+    "rgba": 10
   },
   "danmu-desktop/styles.css": {
     "hex": 19,
-    "gridPx": 103
+    "gridPx": 103,
+    "rgba": 161
   },
   "danmu-desktop/tailwind-input.css": {
     "hex": 0,
-    "gridPx": 0
+    "gridPx": 0,
+    "rgba": 0
   },
   "server/static/css/overlay.css": {
     "hex": 71,
-    "gridPx": 21
+    "gridPx": 21,
+    "rgba": 41
   },
   "server/static/css/style.css": {
     "hex": 326,
-    "gridPx": 831
+    "gridPx": 831,
+    "rgba": 441
   },
   "server/static/css/viewer-v2.css": {
     "hex": 74,
-    "gridPx": 102
+    "gridPx": 102,
+    "rgba": 77
   },
   "server/tailwind.input.css": {
     "hex": 0,
-    "gridPx": 0
+    "gridPx": 0,
+    "rgba": 0
   },
   "shared/hud.css": {
     "hex": 126,
-    "gridPx": 295
+    "gridPx": 295,
+    "rgba": 180
   }
 }

--- a/server/static/css/style.css
+++ b/server/static/css/style.css
@@ -286,8 +286,8 @@ html[data-theme="dark"] .admin-body {
 }
 
 .admin-login-chip.is-accent {
-  background: rgba(56, 189, 248, 0.12);
-  border-color: rgba(56, 189, 248, 0.45);
+  background: var(--hud-cyan-soft, rgba(56, 189, 248, 0.12));
+  border-color: var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   color: var(--color-primary);
 }
 
@@ -480,7 +480,7 @@ body[data-active-route]:not([data-active-route="dashboard"]) .admin-dash-summary
   text-align: center;
 }
 
-.admin-dash-msg-row .tag.is-cyan    { background: rgba(56, 189, 248, 0.12); color: var(--hud-cyan, #38bdf8); border: 1px solid rgba(56, 189, 248, 0.45); }
+.admin-dash-msg-row .tag.is-cyan    { background: var(--hud-cyan-soft, rgba(56, 189, 248, 0.12)); color: var(--hud-cyan, #38bdf8); border: 1px solid rgba(56, 189, 248, 0.45); }
 .admin-dash-msg-row .tag.is-amber   { background: rgba(251, 191, 36, 0.12); color: var(--hud-amber, #fbbf24); border: 1px solid rgba(251, 191, 36, 0.45); }
 .admin-dash-msg-row .tag.is-lime    { background: rgba(134, 239, 172, 0.12); color: var(--hud-lime, #86efac); border: 1px solid rgba(134, 239, 172, 0.45); }
 .admin-dash-msg-row .tag.is-crimson { background: rgba(248, 113, 113, 0.12); color: var(--hud-crimson, #f87171); border: 1px solid rgba(248, 113, 113, 0.45); }
@@ -894,7 +894,7 @@ body[data-active-route]:not([data-active-route="dashboard"]) .admin-dash-summary
   text-transform: uppercase;
 }
 
-.admin-dash-myaction-chip.is-cyan    { background: rgba(56, 189, 248, 0.12); color: var(--hud-cyan, #38bdf8);    border: 1px solid rgba(56, 189, 248, 0.45); }
+.admin-dash-myaction-chip.is-cyan    { background: var(--hud-cyan-soft, rgba(56, 189, 248, 0.12)); color: var(--hud-cyan, #38bdf8);    border: 1px solid rgba(56, 189, 248, 0.45); }
 .admin-dash-myaction-chip.is-amber   { background: rgba(251, 191, 36, 0.12); color: var(--hud-amber, #fbbf24);   border: 1px solid rgba(251, 191, 36, 0.45); }
 .admin-dash-myaction-chip.is-lime    { background: rgba(134, 239, 172, 0.12); color: var(--hud-lime, #86efac);   border: 1px solid rgba(134, 239, 172, 0.45); }
 .admin-dash-myaction-chip.is-crimson { background: rgba(248, 113, 113, 0.12); color: var(--hud-crimson, #f87171); border: 1px solid rgba(248, 113, 113, 0.45); }
@@ -1025,7 +1025,7 @@ body[data-active-route]:not([data-active-route="dashboard"]) .admin-dash-summary
 .admin-dash-poll-opt .bar > span {
   display: block;
   height: 100%;
-  background: rgba(56, 189, 248, 0.45);
+  background: var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   border-radius: var(--radius-xs);
   transition: width var(--motion-slow) ease;
 }
@@ -1665,7 +1665,7 @@ body[data-active-route]:not([data-active-route="dashboard"]) .admin-dash-summary
 }
 
 .admin-vt-device button.is-active {
-  background: rgba(56, 189, 248, 0.12);
+  background: var(--hud-cyan-soft, rgba(56, 189, 248, 0.12));
   color: var(--color-primary);
 }
 
@@ -4569,7 +4569,7 @@ summary:focus-visible {
   transition: border-color var(--motion-normal), background-color var(--motion-normal), color var(--motion-normal);
 }
 .stream-mode-toggle:hover {
-  border-color: rgba(56, 189, 248, 0.45);
+  border-color: var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   color: var(--color-text-primary);
 }
 .stream-mode-toggle input {
@@ -5388,7 +5388,7 @@ body.stream-mode .admin-hero .admin-summary-grid {
   width: 18px;
   height: 18px;
   border-radius: var(--radius-xs);
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  border: 1px solid var(--hud-line-strong, rgba(148, 163, 184, 0.35));
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -5854,7 +5854,7 @@ body.stream-mode .admin-hero .admin-summary-grid {
 }
 .admin-proto-placeholder-btn.is-active {
   color: var(--color-primary);
-  border-color: rgba(56, 189, 248, 0.45);
+  border-color: var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   background: rgba(56, 189, 248, 0.10);
 }
 
@@ -6306,7 +6306,7 @@ body[data-history-tab="replay"] #history-v2-section { display: none !important; 
   font-family: var(--font-mono); font-size: 9px; letter-spacing: 1.2px;
   color: var(--color-primary);
   padding: 2px 8px;
-  background: rgba(56, 189, 248, 0.12);
+  background: var(--hud-cyan-soft, rgba(56, 189, 248, 0.12));
   border: 1px solid rgba(56, 189, 248, 0.40);
   border-radius: var(--radius-2xs);
 }
@@ -6590,7 +6590,7 @@ body[data-history-tab="replay"] #history-v2-section { display: none !important; 
   cursor: pointer;
   transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease, color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, transform var(--motion-fast) ease;
 }
-.admin-setup-lang-card:hover { border-color: rgba(56, 189, 248, 0.45); }
+.admin-setup-lang-card:hover { border-color: var(--hud-cyan-line, rgba(56, 189, 248, 0.45)); }
 .admin-setup-lang-card.is-selected {
   border-color: var(--color-primary);
   background: rgba(56, 189, 248, 0.08);
@@ -6631,7 +6631,7 @@ body[data-history-tab="replay"] #history-v2-section { display: none !important; 
   margin: 0 auto 18px;
   display: flex; align-items: center; justify-content: center;
   background: rgba(56, 189, 248, 0.10);
-  border: 1px solid rgba(56, 189, 248, 0.45);
+  border: 1px solid var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   color: var(--color-primary);
   border-radius: 50%;
   font-size: 32px;
@@ -6856,7 +6856,7 @@ body[data-history-tab="replay"] #history-v2-section { display: none !important; 
 }
 
 .admin-setup-toggle-row:hover {
-  border-color: rgba(56, 189, 248, 0.45);
+  border-color: var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   background: rgba(56, 189, 248, 0.04);
   transform: translateY(-1px);
 }
@@ -7000,7 +7000,7 @@ body[data-setup-wizard-open="1"] { overflow: hidden; }
   display: inline-block;
   padding: 9px 18px;
   background: rgba(56, 189, 248, 0.10);
-  border: 1px solid rgba(56, 189, 248, 0.45);
+  border: 1px solid var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   color: var(--color-primary);
   border-radius: var(--radius-sm);
   font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.4px;
@@ -7190,7 +7190,7 @@ body[data-setup-wizard-open="1"] { overflow: hidden; }
 }
 .admin-pdd-action--primary {
   background: rgba(56, 189, 248, 0.10);
-  border-color: rgba(56, 189, 248, 0.45);
+  border-color: var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   color: var(--color-primary);
 }
 .admin-pdd-action--ghost { color: var(--color-text-muted); }
@@ -7654,7 +7654,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
   margin-top: 16px;
   padding: 4px 14px; border-radius: var(--radius-pill);
   background: rgba(24, 34, 57, 0.53);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   font-family: var(--font-mono);
   font-size: 9px; letter-spacing: 0.5px;
   color: rgba(148, 163, 184, 0.40);
@@ -8031,7 +8031,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
 .admin-mobile-nav__overflow {
   position: absolute; left: 0; right: 0; bottom: 56px;
   background: var(--color-surface);
-  border-top: 1px solid rgba(148, 163, 184, 0.18);
+  border-top: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.5);
   animation: hud-mobile-nav-slide 200ms ease-out;
 }
@@ -8078,7 +8078,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
 .admin-mobile-nav__bar {
   display: flex; height: 56px;
   background: var(--color-surface);
-  border-top: 1px solid rgba(148, 163, 184, 0.18);
+  border-top: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   /* Honour iOS home-bar safe area. */
   padding-bottom: env(safe-area-inset-bottom);
 }
@@ -8289,7 +8289,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
   display: flex; align-items: center; gap: 6px;
   padding: 5px 12px; border-radius: var(--radius-sm);
   background: var(--color-bg-elevated, #182239);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
 }
 .admin-mq__autoreject-label {
   font-family: var(--font-mono);
@@ -8361,7 +8361,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
 /* Card */
 .admin-mq-card {
   background: var(--color-surface);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   border-left: 3px solid var(--mq-sev, var(--color-text-muted));
   border-radius: var(--radius-md-sm);
   padding: 12px;
@@ -8398,7 +8398,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
 .admin-mq-card__body {
   padding: 8px 10px; border-radius: var(--radius-sm);
   background: var(--color-bg-elevated, #182239);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   font-size: 12px; line-height: 1.6;
   color: var(--color-text-strong);
   word-break: break-word;
@@ -8418,7 +8418,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
   font-family: var(--font-mono);
   font-size: 9px; letter-spacing: 0.3px;
   padding: 2px 8px; border-radius: var(--radius-xs);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   color: var(--color-text-muted);
 }
 .admin-mq-card__countdown {
@@ -8455,7 +8455,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
 }
 .admin-mq-card__btn--more {
   flex: 0; padding: 6px 10px;
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   background: transparent;
   color: var(--color-text-muted);
 }
@@ -8477,7 +8477,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
 
 .admin-mq__footer {
   padding: 8px 14px;
-  border-top: 1px solid rgba(148, 163, 184, 0.18);
+  border-top: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   display: flex; align-items: center; gap: 16px;
   font-family: var(--font-mono);
   font-size: 10px; letter-spacing: 0.5px;
@@ -8525,7 +8525,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
 }
 
 .admin-hud-modal--danger  .admin-hud-modal__panel { border-color: rgba(255, 77, 79, 0.45); }
-.admin-hud-modal--info    .admin-hud-modal__panel { border-color: rgba(56, 189, 248, 0.45); }
+.admin-hud-modal--info    .admin-hud-modal__panel { border-color: var(--hud-cyan-line, rgba(56, 189, 248, 0.45)); }
 .admin-hud-modal--success .admin-hud-modal__panel { border-color: rgba(132, 225, 0, 0.45); }
 
 .admin-hud-modal__head {
@@ -8569,7 +8569,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
 .admin-hud-modal__foot {
   display: flex; gap: 10px; justify-content: flex-end;
   padding: 12px 20px;
-  border-top: 1px solid rgba(148, 163, 184, 0.18);
+  border-top: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
 }
 .admin-hud-modal__btn {
   padding: 8px 20px; border-radius: var(--radius-sm); cursor: pointer;
@@ -8620,14 +8620,14 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
 
 .admin-skel-card {
   background: var(--color-surface);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   border-radius: var(--radius-md-sm); overflow: hidden;
 }
 
 .admin-skel-list__head {
   display: flex; gap: 40px;
   padding: 10px 16px;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  border-bottom: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
 }
 .admin-skel-list__row {
   display: flex; align-items: center; gap: 12px;
@@ -8670,7 +8670,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
   margin: 40px auto;
   padding: 48px 36px; text-align: center;
   background: var(--color-surface);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   border-radius: var(--radius-md-sm);
 }
 .admin-empty__icon {
@@ -8713,7 +8713,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
   display: flex; align-items: center; gap: 10px;
   padding: 10px 16px; border-radius: var(--radius-md-sm);
   background: rgba(148, 163, 184, 0.04);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   font-size: 11px; color: var(--color-text-muted);
   margin-bottom: 12px;
 }
@@ -8731,13 +8731,13 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
 
 .admin-flt-v4__card {
   background: var(--color-surface);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   border-radius: var(--radius-md-sm); overflow: hidden;
   margin-bottom: 14px;
 }
 .admin-flt-v4__head {
   padding: 12px 16px;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  border-bottom: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
 }
 .admin-flt-v4__kicker {
   font-family: var(--font-mono);
@@ -8751,7 +8751,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
 .admin-flt-v4__qchip {
   padding: 10px 18px; border-radius: var(--radius-md-sm); cursor: pointer;
   background: transparent;
-  border: 1.5px solid rgba(148, 163, 184, 0.18);
+  border: 1.5px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   display: flex; align-items: center; gap: 10px;
   font-family: var(--font-sans);
 }
@@ -8820,7 +8820,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
 
 .admin-ev-v4__card {
   background: var(--color-surface);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   border-radius: var(--radius-md-sm); overflow: hidden;
 }
 .admin-ev-v4__row {
@@ -9198,7 +9198,7 @@ body.admin-rcb-exhausted .admin-app-shell { opacity: 0.3; }
   width: 100%; max-width: 480px;
   height: 100vh;
   background: var(--color-surface);
-  border-left: 1px solid rgba(56, 189, 248, 0.45);
+  border-left: 1px solid var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   box-shadow: -16px 0 40px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(56, 189, 248, 0.15);
   padding: 18px 18px 24px;
   overflow: auto;
@@ -10690,7 +10690,7 @@ body[data-message-drawer-open="1"] .admin-msgd-overlay { pointer-events: auto; }
 .admin-wh-card:hover { background: rgba(56, 189, 248, 0.04); }
 .admin-wh-card.is-selected {
   background: rgba(56, 189, 248, 0.10);
-  border-color: rgba(56, 189, 248, 0.45);
+  border-color: var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
 }
 .admin-wh-card-head {
   display: flex;
@@ -10988,7 +10988,7 @@ body[data-message-drawer-open="1"] .admin-msgd-overlay { pointer-events: auto; }
   flex-shrink: 0;
 }
 .admin-session-pause-btn.is-paused {
-  background: rgba(56, 189, 248, 0.12);
+  background: var(--hud-cyan-soft, rgba(56, 189, 248, 0.12));
   border-color: var(--color-primary);
 }
 .admin-session-live-behavior {
@@ -11057,7 +11057,7 @@ body[data-message-drawer-open="1"] .admin-msgd-overlay { pointer-events: auto; }
 
 .admin-tabs-btn.is-active {
   color: #38bdf8;
-  border-bottom-color: rgba(56, 189, 248, 0.45);
+  border-bottom-color: var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   background: rgba(56, 189, 248, 0.08);
 }
 
@@ -11150,7 +11150,7 @@ body[data-message-drawer-open="1"] .admin-msgd-overlay { pointer-events: auto; }
 
 .admin-system-accordion-row.is-open {
   background: rgba(56, 189, 248, 0.08);
-  border-color: rgba(56, 189, 248, 0.45);
+  border-color: var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   color: #38bdf8;
 }
 
@@ -11254,7 +11254,7 @@ body[data-message-drawer-open="1"] .admin-msgd-overlay { pointer-events: auto; }
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid rgba(56, 189, 248, 0.45);
+  border: 1px solid var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   border-radius: var(--radius-md-sm);
   background: rgba(56, 189, 248, 0.10);
   color: var(--hud-cyan, var(--color-primary));
@@ -12941,7 +12941,7 @@ body[data-message-drawer-open="1"] .admin-msgd-overlay { pointer-events: auto; }
 .admin-sch-cal-chip.is-poll    { background: rgba(251, 191, 36, 0.18); border: 1px solid rgba(251, 191, 36, 0.35); color: var(--hud-amber, #fbbf24); }
 .admin-sch-cal-chip.is-msg     { background: rgba(56, 189, 248, 0.18); border: 1px solid rgba(56, 189, 248, 0.35); color: var(--hud-cyan, #38bdf8); }
 .admin-sch-cal-chip.is-theme   { background: rgba(134, 239, 172, 0.18); border: 1px solid rgba(134, 239, 172, 0.35); color: var(--hud-lime, #86efac); }
-.admin-sch-cal-chip.is-mute    { background: rgba(148, 163, 184, 0.12); border: 1px solid rgba(148, 163, 184, 0.35); color: var(--admin-text-dim); }
+.admin-sch-cal-chip.is-mute    { background: rgba(148, 163, 184, 0.12); border: 1px solid var(--hud-line-strong, rgba(148, 163, 184, 0.35)); color: var(--admin-text-dim); }
 .admin-sch-cal-chip.is-webhook { background: rgba(56, 189, 248, 0.18); border: 1px solid rgba(56, 189, 248, 0.35); color: var(--hud-cyan, #38bdf8); }
 
 /* ──────────────────────────────────────────────────────────────────────
@@ -13405,7 +13405,7 @@ body[data-message-drawer-open="1"] .admin-msgd-overlay { pointer-events: auto; }
 }
 
 .admin-fp-state.is-cyan {
-  border-color: rgba(56, 189, 248, 0.45);
+  border-color: var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   color: var(--hud-cyan, #38bdf8);
   background: rgba(56, 189, 248, 0.06);
 }
@@ -14363,7 +14363,7 @@ body.admin-pu-open { overflow: hidden; }
   display: flex; align-items: center; gap: 14px;
   padding: 14px 16px;
   border-radius: var(--radius-md-sm);
-  border: 1.5px dashed rgba(56, 189, 248, 0.45);
+  border: 1.5px dashed var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   background: rgba(56, 189, 248, 0.05);
   cursor: pointer;
   transition: background var(--motion-fast), border-color var(--motion-fast);
@@ -14377,7 +14377,7 @@ body.admin-pu-open { overflow: hidden; }
   width: 38px; height: 38px; border-radius: var(--radius-sm);
   flex-shrink: 0;
   border: 1px solid var(--hud-cyan, #38bdf8);
-  background: rgba(56, 189, 248, 0.12);
+  background: var(--hud-cyan-soft, rgba(56, 189, 248, 0.12));
   display: flex; align-items: center; justify-content: center;
   font-size: 18px; color: var(--hud-cyan, #38bdf8);
 }

--- a/server/static/css/viewer-v2.css
+++ b/server/static/css/viewer-v2.css
@@ -1775,8 +1775,8 @@ body.viewer-has-topstrip .viewer-topstrip {
   background: rgba(248, 113, 113, 0.2);
 }
 .viewer-offline-btn.is-secondary {
-  border-color: rgba(56, 189, 248, 0.45);
-  background: rgba(56, 189, 248, 0.12);
+  border-color: var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
+  background: var(--hud-cyan-soft, rgba(56, 189, 248, 0.12));
   color: #7dd3fc;
 }
 
@@ -2035,7 +2035,7 @@ body[data-viewer-state] {
   padding: 6px 14px;
   border-radius: var(--radius-pill);
   background: rgba(56, 189, 248, 0.10);
-  border: 1px solid rgba(56, 189, 248, 0.45);
+  border: 1px solid var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   font-family: var(--font-mono, "JetBrains Mono", ui-monospace, monospace);
   font-size: 13px;
   font-weight: 600;

--- a/server/static/js/admin-audience.js
+++ b/server/static/js/admin-audience.js
@@ -346,7 +346,7 @@
     detail.innerHTML =
       '<div class="admin-aud-detail-head">' +
         '<span class="admin-ui-pill admin-aud-risk-pill ' + _riskClassFor(risk.level) + '">' + escapeHtml(risk.label) + '</span>' +
-        '<button type="button" class="admin-ui-action admin-aud-detail-close" data-aud-action="close-detail" aria-label="關閉">✕</button>' +
+        '<button type="button" class="admin-ui-action admin-aud-detail-close" data-aud-action="close-detail" aria-label="關閉">' + window.AdminUtils.closeIcon + '</button>' +
       '</div>' +
       '<div class="admin-aud-detail-id">' +
         '<span class="avatar" style="background:' + color + '">' + escapeHtml(initial) + '</span>' +

--- a/server/static/js/admin-dashboard.js
+++ b/server/static/js/admin-dashboard.js
@@ -190,7 +190,7 @@
       `<div class="admin-dash-qp-row">` +
         `<span class="key">${letter}</span>` +
         `<input type="text" placeholder="選項 ${letter}" maxlength="60" />` +
-        `<button type="button" class="rm" data-qp-rm ${removable ? "" : "hidden"}>✕</button>` +
+        `<button type="button" class="rm" data-qp-rm ${removable ? "" : "hidden"}>${window.AdminUtils.closeIcon}</button>` +
       `</div>`
     );
   }

--- a/server/static/js/admin-emojis.js
+++ b/server/static/js/admin-emojis.js
@@ -95,7 +95,7 @@
       '<span class="admin-em-v4__tile-dot" aria-label="enabled"></span>' +
       '<div class="admin-em-v4__tile-actions">' +
       '<button type="button" class="emoji-copy-btn" data-label="' + escapeAttr(label) + '" title="' + escapeAttr(ServerI18n.t("copyToClipboard")) + '">複製</button>' +
-      '<button type="button" class="emoji-delete-btn" data-name="' + escapeAttr(emoji.name) + '" title="' + escapeAttr(ServerI18n.t("deleteEmoji")) + '">×</button>' +
+      '<button type="button" class="emoji-delete-btn" data-name="' + escapeAttr(emoji.name) + '" title="' + escapeAttr(ServerI18n.t("deleteEmoji")) + '">' + window.AdminUtils.closeIcon + '</button>' +
       '</div>' +
       '</div>'
     );

--- a/server/static/js/admin-help-drawer.js
+++ b/server/static/js/admin-help-drawer.js
@@ -261,7 +261,7 @@
         <span class="admin-help__title" id="admin-help-title">Help</span>
         <kbd class="admin-help__kbd admin-help__head-kbd">⌘ /</kbd>
         <span class="admin-help__spacer"></span>
-        <button type="button" class="admin-help__close" data-help-close aria-label="Close">✕</button>
+        <button type="button" class="admin-help__close" data-help-close aria-label="Close">${window.AdminUtils.closeIcon}</button>
       </header>
       <div class="admin-help__body">
 

--- a/server/static/js/admin-message-drawer.js
+++ b/server/static/js/admin-message-drawer.js
@@ -202,7 +202,7 @@
       <header class="admin-msgd-v4__topbar">
         <span class="admin-msgd-v4__kicker">MESSAGE DETAIL</span>
         <span class="admin-msgd-v4__spacer"></span>
-        <button type="button" class="admin-msgd-v4__close" data-msgd-action="close" title="關閉 · Esc">✕</button>
+        <button type="button" class="admin-msgd-v4__close" data-msgd-action="close" title="關閉 · Esc">${window.AdminUtils.closeIcon}</button>
       </header>
 
       <div class="admin-msgd-v4__header">

--- a/server/static/js/admin-notifications.js
+++ b/server/static/js/admin-notifications.js
@@ -414,7 +414,7 @@
       <div class="admin-notif-detail-head">
         <span class="admin-ui-monolabel">DETAIL</span>
         <span class="admin-ui-spacer"></span>
-        <button type="button" class="admin-ui-action admin-notif-detail-close" data-notif-action="close-detail" aria-label="關閉">✕</button>
+        <button type="button" class="admin-ui-action admin-notif-detail-close" data-notif-action="close-detail" aria-label="關閉">${window.AdminUtils.closeIcon}</button>
       </div>
       <div class="admin-ui-pill admin-notif-detail-sev ${_sevClassFor(it.sev)}">
         <span class="badge">${escapeHtml(sev.label)}</span>

--- a/server/static/js/admin-plugins-upload.js
+++ b/server/static/js/admin-plugins-upload.js
@@ -49,7 +49,7 @@
       <div class="admin-pu-modal" role="dialog" aria-label="上傳插件">
         <header class="admin-pu-head">
           <span class="admin-ui-monolabel" style="color:var(--color-primary)">上傳插件</span>
-          <button type="button" class="admin-pu-close" aria-label="關閉" data-pu-close>✕</button>
+          <button type="button" class="admin-pu-close" aria-label="關閉" data-pu-close>${window.AdminUtils.closeIcon}</button>
         </header>
         <nav class="admin-pu-steps" data-pu-steps aria-label="安裝進度"></nav>
         <div class="admin-pu-body" data-pu-body></div>

--- a/server/static/js/admin-poll-builder.js
+++ b/server/static/js/admin-poll-builder.js
@@ -245,7 +245,7 @@
                   ${opt.img ? '<span class="img-on">🖼</span>' : '<span class="img-off">+ 圖</span>'}
                 </button>
                 <input type="text" data-ed-opt-text="${opt.id}" value="${escapeHtml(opt.label || "")}" placeholder="選項 ${String.fromCharCode(65 + oi)}" maxlength="100" />
-                ${q.options.length > 2 ? `<button type="button" class="opt-remove" data-ed-opt-remove="${opt.id}" title="刪除">×</button>` : ""}
+                ${q.options.length > 2 ? `<button type="button" class="opt-remove" data-ed-opt-remove="${opt.id}" title="刪除">${window.AdminUtils.closeIcon}</button>` : ""}
               </div>
             `).join("")}
             ${q.options.length < 6 ? `<button type="button" class="admin-poll-opt-add" data-ed-opt-add>＋ 新增選項 (${q.options.length}/6)</button>` : ""}

--- a/server/static/js/admin-reconnect-banner.js
+++ b/server/static/js/admin-reconnect-banner.js
@@ -91,7 +91,7 @@
       <div class="admin-rcb__progress"><div class="admin-rcb__progress-fill" style="width:${pct}%"></div></div>
       <span class="admin-rcb__spacer"></span>
       <button type="button" class="admin-rcb__btn admin-rcb__btn--ghost" data-rcb-action="dismiss">離線繼續工作</button>
-      <button type="button" class="admin-rcb__close" data-rcb-action="dismiss" aria-label="Dismiss">✕</button>`;
+      <button type="button" class="admin-rcb__close" data-rcb-action="dismiss" aria-label="Dismiss">${window.AdminUtils.closeIcon}</button>`;
   }
 
   function _exhaustedHtml() {
@@ -104,7 +104,7 @@
       <span class="admin-rcb__hint">check network or restart server</span>
       <span class="admin-rcb__spacer"></span>
       <button type="button" class="admin-rcb__btn admin-rcb__btn--retry" data-rcb-action="retry">立即重試</button>
-      <button type="button" class="admin-rcb__close" data-rcb-action="dismiss" aria-label="Dismiss">✕</button>`;
+      <button type="button" class="admin-rcb__close" data-rcb-action="dismiss" aria-label="Dismiss">${window.AdminUtils.closeIcon}</button>`;
   }
 
   function _tick() {

--- a/server/static/js/admin-scheduler.js
+++ b/server/static/js/admin-scheduler.js
@@ -25,7 +25,7 @@
         <input type="number" min="12" max="200" placeholder="Size"
           class="scheduler-msg-size admin-ui-input"
           value="${size || 48}" />
-        <button type="button" class="admin-ui-chip is-danger scheduler-remove-msg" title="Remove" aria-label="Remove message">×</button>
+        <button type="button" class="admin-ui-chip is-danger scheduler-remove-msg" title="Remove" aria-label="Remove message">${window.AdminUtils.closeIcon}</button>
       </div>`;
   }
 
@@ -58,7 +58,7 @@
             ${isPaused ? "▶" : "⏸"}
           </button>
           <button type="button" class="admin-ui-chip is-danger scheduler-job-cancel"
-            data-job-id="${escapeAttr(job.id)}">×</button>
+            data-job-id="${escapeAttr(job.id)}">${window.AdminUtils.closeIcon}</button>
         </div>
       </div>`;
   }

--- a/server/static/js/admin-setup-wizard.js
+++ b/server/static/js/admin-setup-wizard.js
@@ -159,7 +159,7 @@
               <div class="admin-setup-brand-name">Danmu Fire</div>
               <div class="admin-setup-brand-sub">SETUP WIZARD · v5 YELLOW</div>
             </div>
-            <button type="button" class="admin-setup-close" data-setup-action="close" aria-label="Close wizard">✕</button>
+            <button type="button" class="admin-setup-close" data-setup-action="close" aria-label="Close wizard">${window.AdminUtils.closeIcon}</button>
           </header>
 
           <div class="admin-setup-stepbar" data-setup-stepbar>

--- a/server/static/js/admin-sounds.js
+++ b/server/static/js/admin-sounds.js
@@ -111,7 +111,7 @@
           "</div>" +
           '<div class="actions" style="margin-top:6px">' +
           '<button type="button" class="admin-ui-chip is-active sound-play-btn" data-name="' + escapeHtml(sound.name) + '">▶ ' + escapeHtml(ServerI18n.t("previewBtn")) + "</button>" +
-          '<button type="button" class="admin-ui-chip is-danger sound-delete-btn" data-name="' + escapeHtml(sound.name) + '">×</button>' +
+          '<button type="button" class="admin-ui-chip is-danger sound-delete-btn" data-name="' + escapeHtml(sound.name) + '">' + window.AdminUtils.closeIcon + '</button>' +
           "</div>" +
           "</div>"
         );
@@ -252,7 +252,7 @@
           '<div class="admin-sounds-rule-trigger">' + escapeHtml(triggerLabel) + "</div>" +
           '<div class="admin-sounds-rule-detail">' + escapeHtml(detail) + "</div>" +
           "</div>" +
-          '<button type="button" class="admin-ui-chip is-danger sound-rule-del-btn" data-rule-id="' + escapeHtml(String(rule.id)) + '">×</button>' +
+          '<button type="button" class="admin-ui-chip is-danger sound-rule-del-btn" data-rule-id="' + escapeHtml(String(rule.id)) + '">' + window.AdminUtils.closeIcon + '</button>' +
           "</div>"
         );
       })

--- a/server/static/js/admin-stickers.js
+++ b/server/static/js/admin-stickers.js
@@ -132,7 +132,7 @@
             '<button type="button" class="admin-ui-chip admin-sticker-pack-action" data-pack-action="up" data-pack-id="' + escapeAttr(pack.id) + '" title="上移">↑</button>' +
             '<button type="button" class="admin-ui-chip admin-sticker-pack-action" data-pack-action="down" data-pack-id="' + escapeAttr(pack.id) + '" title="下移">↓</button>' +
             '<button type="button" class="admin-ui-chip admin-sticker-pack-action" data-pack-action="toggle" data-pack-id="' + escapeAttr(pack.id) + '" title="' + (pack.enabled ? "停用" : "啟用") + '">' + (pack.enabled ? "ON" : "OFF") + '</button>' +
-            '<button type="button" class="admin-ui-chip is-danger admin-sticker-pack-action" data-pack-action="delete" data-pack-id="' + escapeAttr(pack.id) + '" title="刪除貼圖包">×</button>' +
+            '<button type="button" class="admin-ui-chip is-danger admin-sticker-pack-action" data-pack-action="delete" data-pack-id="' + escapeAttr(pack.id) + '" title="刪除貼圖包">' + window.AdminUtils.closeIcon + '</button>' +
           '</div>';
       html +=
         '<div class="' + rowCls + '" data-pack="' + escapeAttr(pack.id) + '" style="display:flex;flex-direction:column;gap:4px">' +
@@ -161,7 +161,7 @@
       escapeAttr(label) + '" title="' + escapeAttr(ServerI18n.t("copyToClipboard")) + '">' +
       escapeHtml(ServerI18n.t("copyBtn")) + "</button>" +
       '<button type="button" class="admin-ui-chip is-danger sticker-delete-btn" data-name="' +
-      escapeAttr(sticker.name) + '" title="' + escapeAttr(ServerI18n.t("deleteSticker")) + '">×</button>' +
+      escapeAttr(sticker.name) + '" title="' + escapeAttr(ServerI18n.t("deleteSticker")) + '">' + window.AdminUtils.closeIcon + '</button>' +
       "</div>" +
       "</div>"
     );

--- a/server/static/js/admin-utils.js
+++ b/server/static/js/admin-utils.js
@@ -30,10 +30,22 @@
     return div.innerHTML;
   }
 
+  // Shared close/dismiss/remove glyph. Replaces the ad-hoc ✕ / × text nodes
+  // (mixed U+2715 and U+00D7) scattered across admin modules with one crisp,
+  // theme-aware SVG: strokes currentColor so it inherits each button's color
+  // in both light/dark, sizes to 1em so it scales with the button's font-size,
+  // and is aria-hidden (every call site carries its own aria-label / title).
+  var CLOSE_ICON =
+    '<svg class="admin-icon-close" viewBox="0 0 24 24" width="1em" height="1em" ' +
+    'fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" ' +
+    'style="vertical-align:middle" aria-hidden="true" focusable="false">' +
+    '<path d="M6 6l12 12M18 6 6 18"/></svg>';
+
   window.AdminUtils = {
     DETAILS_STATE_KEY: DETAILS_STATE_KEY,
     loadDetailsState: loadDetailsState,
     saveDetailsState: saveDetailsState,
     escapeHtml: escapeHtml,
+    closeIcon: CLOSE_ICON,
   };
 })();

--- a/server/static/js/admin-webhooks.js
+++ b/server/static/js/admin-webhooks.js
@@ -560,7 +560,7 @@
         '<span class="dot" style="background:' + dotColor + ';box-shadow:0 0 6px ' + dotColor + '"></span>' +
         '<span class="name">' + _escHtml(_formatHostname(hook.url)) + '</span>' +
         '<span class="admin-ui-spacer" aria-hidden="true"></span>' +
-        '<button type="button" class="admin-ui-action admin-wh-detail-close" data-wh-action="close-detail" aria-label="關閉">✕</button>' +
+        '<button type="button" class="admin-ui-action admin-wh-detail-close" data-wh-action="close-detail" aria-label="關閉">' + window.AdminUtils.closeIcon + '</button>' +
       '</div>' +
       '<div class="admin-ui-monolabel admin-wh-detail-label">事件訂閱</div>' +
       '<div class="admin-wh-detail-events">' + eventsHtml + '</div>' +

--- a/server/static/js/admin.js
+++ b/server/static/js/admin.js
@@ -946,8 +946,8 @@ document.addEventListener("DOMContentLoaded", () => {
                                         <button type="button" class="admin-dash-qa-cta is-amber" data-qa-poll-expand>新建 ▶</button>
                                       </div>
                                       <div class="admin-dash-qp-options admin-dash-qa-options" data-qp="options" hidden>
-                                        <div class="admin-dash-qp-row"><span class="key">A</span><input type="text" placeholder="選項 A" maxlength="60" /><button type="button" class="rm" data-qp-rm hidden>✕</button></div>
-                                        <div class="admin-dash-qp-row"><span class="key">B</span><input type="text" placeholder="選項 B" maxlength="60" /><button type="button" class="rm" data-qp-rm hidden>✕</button></div>
+                                        <div class="admin-dash-qp-row"><span class="key">A</span><input type="text" placeholder="選項 A" maxlength="60" /><button type="button" class="rm" data-qp-rm hidden>${window.AdminUtils.closeIcon}</button></div>
+                                        <div class="admin-dash-qp-row"><span class="key">B</span><input type="text" placeholder="選項 B" maxlength="60" /><button type="button" class="rm" data-qp-rm hidden>${window.AdminUtils.closeIcon}</button></div>
                                       </div>
                                       <div class="admin-dash-qp-foot" data-qa-poll-foot hidden>
                                         <a href="#" class="admin-dash-qp-add" data-qp-add>+ 新增選項</a>

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -143,7 +143,7 @@
             <div class="viewer-mobile-sheet-grabber" aria-hidden="true"></div>
             <div class="viewer-mobile-sheet-head">
               <span class="viewer-mobile-sheet-title" data-i18n="settings">設定</span>
-              <button type="button" class="viewer-mobile-sheet-close" data-mobile-sheet-close aria-label="關閉">✕</button>
+              <button type="button" class="viewer-mobile-sheet-close" data-mobile-sheet-close aria-label="關閉"><svg class="viewer-icon-close" viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" style="vertical-align:middle" aria-hidden="true" focusable="false"><path d="M6 6l12 12M18 6 6 18"/></svg></button>
             </div>
             <!-- Theme tri-state. Hidden by JS when admin forces ViewerThemeMode. -->
             <div class="viewer-mobile-sheet-row" data-viewer-mobile-theme-row>


### PR DESCRIPTION
延續 #120 CSS token retrofit / UIUX 統一。三個 atomic commit,每個都獨立驗證過。

## ① `refactor(css)` — 47 個主題可變 rgba 折成 token(Batch 2b)
Batch 2a(#147)折的是**主題不變**的 rgba(兩主題 byte-identical)。這批是**主題可變**的:47 個等於某 theme-variable token `:root`(dark)值的裸 rgba,折成 `var(--token, <原rgba>)`。

- **dark 主題 byte-identical**(token `:root` == literal,in-browser computed 值實測確認)。
- **light 主題**改成 token 的設計 override —— 這正是要修的 light 適配(sky 邊 → sky-600、slate hairline → 深線 on 白)。
- Scope = 有 light 主題的兩個 admin 面(`style.css` 46 · `viewer-v2.css` 1)。
- By token:`--hud-cyan-line` 19 / `--color-border-soft` 18 / `--hud-cyan-soft` 8 / `--hud-line-strong` 2。
- **刻意排除**:裝飾性 scanline/grid gradient、`body.is-dark` scope 的 chip 邊、token 定義行、已在 var() fallback 內的 rgba;Electron 桌面 CSS + overlay.css(恆暗、無 light 切換)不在此批。

## ② `feat(lint)` — rgba 裸值納入 check-css-tokens 棘輪
在既有 hex + gridPx 之外加第三個 per-file metric:計數**不在 `var(--token, rgba(...))` fallback 內**的裸 `rgb()/rgba()`。折疊 idiom 是理想終態,所以 fallback 內的 rgba **不計** —— 折一個裸 literal 進 token 一定**降低**此值(獎勵 retrofit),新增硬編 rgba 則**升高**(擋下)。與既有閘同樣非破壞式(鎖現值、只擋成長),舊 baseline entry 的新 metric grandfather 成 Infinity。

## ③ `refactor(ui)` — 21 個 ✕/× 關閉 glyph → 共用 SVG icon(Batch 3b)
關閉/刪除鈕原本混用 U+2715(✕)與 U+00D7(×)純文字 glyph,靠系統字型渲染。統一成 `window.AdminUtils.closeIcon` 的單一 SVG:`stroke=currentColor` 隨主題色、`1em` 隨字級縮放、`vertical-align:middle`、`aria-hidden`(各站點自帶 aria-label/title)。

- 轉換 21 個**真**關閉鈕(16 檔);viewer `index.html`(不載 AdminUtils)inline SVG。
- **審計關鍵**:× 嚴重超載,原「71 glyph」裡多數是速度倍率 `2×`、尺寸 `1920×1080`、QR 圖樣、註解 —— 全數保留不動,只換 `>✕</button>` 這種 content-glyph 關閉鈕。

## 驗證
- `make lint-css` 綠;`npm run build:css` 不動 `tailwind.css`(scanner 地雷未觸發)。
- Admin 審核頁 dark + light 雙截圖:dark 質感無回歸、light hairline/青邊正確適配。
- rgba 棘輪:注入一個裸 rgba 到 overlay.css → 41→42 被擋;還原後綠。
- ✕→SVG:所有改動 JS 過 `node --check`;help-drawer 關閉鈕 14×14 完全置中、currentColor 雙主題確認;無新 console 錯誤。

Refs #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized close and delete controls across admin interfaces with a consistent, theme-aware icon.
  * Updated mobile settings controls to use the refreshed close icon.
  * Replaced hardcoded color values across dashboard and viewer styles with shared theme tokens.

* **Bug Fixes**
  * Improved CSS linting to detect un-tokenized RGBA colors and prevent new violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->