### PR TITLE
feat(css): oklch primitive palette layer — color system v2, Phase 1 (#120)

### DIFF
--- a/docs/color-system-v2-proposal.md
+++ b/docs/color-system-v2-proposal.md
@@ -1,0 +1,180 @@
+# 色彩系統 v2 設計提案（tokens.css core）
+
+> 狀態：**提案 · 待決策**（2026-07-24）。不動碼,先讓人審。
+> 合併 Issue #120 的兩個「重寫顏色核心」項目:**③(c) oklch 遷移** + **④ primitive 50–950 色階**。
+> 這兩件本質是同一件事,分兩次做 = 對 `shared/tokens.css` 核心動兩刀,故合成一份。
+
+---
+
+## 0. TL;DR — 一句話與建議
+
+現在 `tokens.css` 是「**semantic token 直接持 hex/rgba**、light 主題靠整段重宣告(且在 `@media` 裡再複製一次)」。提案改成三層:
+
+```
+primitive（oklch,固定）  →  semantic（light-dark() 綁雙主題）  →  component/alias
+```
+
+**建議採用組合**:`primitive 層（seed 自 Tailwind v4 oklch)` + `light-dark()` 消除主題重複 + **Phase 化、零視覺變化優先**。單一最大收益不是 oklch 本身,而是 **`light-dark()` 把 ~130 行重複的主題 override 收斂成 0**。
+
+---
+
+## 1. 現況（紮根事實,全部出自 `shared/tokens.css`）
+
+### 1.1 沒有 primitive 層
+Semantic token 直接寫死原始值,註解裡才提 Tailwind 色名 —— 但**沒有對應的 `--sky-400` primitive**:
+
+```css
+--color-primary: #38bdf8;          /* 註解說 sky-400,但沒有 --sky-400 token */
+--color-text-secondary: #94a3b8;   /* slate-400 */
+--hud-cyan-line: rgba(56, 189, 248, 0.45);  /* sky-400 @ 0.45 */
+```
+清點:**~150 個色值定義（101 hex + 49 rgba）**,幾乎全是 Tailwind v3 調色盤色。
+
+### 1.2 light 主題 = 整段重宣告 ×2（核心痛點）
+Light 主題不是「翻映射」,是把 ~50 個 semantic token **整段重寫**,而且**同一段複製在兩個地方**:
+
+| 位置 | 內容 |
+|---|---|
+| `:root[data-theme="light"]`（L240-309） | ~50 個 token override |
+| `@media (prefers-color-scheme: light) :root:not(...)`（L314-368） | **同樣 ~50 個,幾乎逐行複製** |
+
+= **~130 行重複的主題 override**。記憶裡早有此警告(雙軌 token 容易 drift)。CSS custom property 無法用選擇器合併「屬性選擇器 + media query」,所以現況沒辦法 DRY —— **除非改機制**。
+
+### 1.3 light 的「-2 steps darker」是手挑 hex,但其實是系統性的
+註解明說 accent 在 light「shift -2 steps darker(sky-400 → sky-600)以保 WCAG AA on white」。實際比對:
+
+| token | dark | light | 調色盤關係 |
+|---|---|---|---|
+| `--color-primary` | `#38bdf8` sky-400 | `#0284c7` sky-600 | **+2 階** |
+| `--color-warning` | `#fbbf24` amber-400 | `#d97706` amber-600 | **+2 階** |
+| `--color-error` | `#ef4444` red-500 | `#dc2626` red-600 | +1 階 |
+| `--color-success` | `#22c55e` green-500 | `#16a34a` green-600 | +1 階 |
+
+這正是 primitive 色階能**系統化**的東西:light = 「semantic 指向高 2 階的 primitive」,而非手挑一個新 hex。
+
+---
+
+## 2. 提案架構
+
+### Layer 0 — primitive（oklch,主題無關,固定）
+從專案已安裝的 **Tailwind v4 `theme.css` 直接種入真實 oklch 值**(不是我手算的近似):
+
+```css
+:root {
+  /* sky */
+  --sky-100: oklch(95.1% 0.026 236.824);
+  --sky-400: oklch(74.6% 0.16  232.661);
+  --sky-500: oklch(68.5% 0.169 237.323);
+  --sky-600: oklch(58.8% 0.158 241.966);
+  --sky-900: oklch(39.1% 0.09  240.876);
+  /* slate */
+  --slate-100: oklch(96.8% 0.007 247.896);
+  --slate-400: oklch(70.4% 0.04  256.788);
+  --slate-600: oklch(44.6% 0.043 257.281);
+  --slate-900: oklch(20.8% 0.042 265.755);
+  /* amber / red / green / emerald / cyan … 同法 */
+}
+```
+只需引入專案**實際用到的色相**(sky · slate · amber · red · green · emerald · cyan)× 需要的階(50/100/…/900/950),不是全 22 色相全量。
+
+### Layer 1 — semantic（用 `light-dark()` 一行綁雙主題）
+```css
+:root {
+  color-scheme: light dark;   /* 啟用 light-dark() */
+
+  --color-primary:        light-dark(var(--sky-600),   var(--sky-400));
+  --color-warning:        light-dark(var(--amber-600), var(--amber-400));
+  --color-text-primary:   light-dark(var(--slate-900), var(--slate-100));
+  --color-bg-base:        light-dark(#ffffff,          var(--slate-900));
+  --color-border:         light-dark(oklch(20.8% 0.042 265.755 / 0.10),
+                                      oklch(100% 0 0 / 0.10));
+  /* … 一個 token 一行,兩主題都在裡面 … */
+}
+```
+主題切換改成控制 `color-scheme`,**不再重宣告任何 token**:
+```css
+:root[data-theme="dark"]  { color-scheme: dark; }
+:root[data-theme="light"] { color-scheme: light; }
+/* auto 模式::root 的 `color-scheme: light dark` 讓 light-dark() 跟隨系統偏好 */
+```
+→ **L220-368 那整塊(~150 行)`[data-theme=light]` + `@media` 重複全部刪除。**
+
+### Layer 2 — component / alias
+`--hud-*`、`--admin-*`、legacy alias 繼續存在,改成引用 semantic(很多已經是 `var(--color-…)`)。消費端 CSS(style.css 等)全走 `var(--token)`,**不需要動**。
+
+---
+
+## 3. 為什麼 oklch
+
+- **感知均勻**:同 lightness 的不同色相看起來一樣亮,scale 產生一致;「-2 階 darker」變成可預測的 L 位移。
+- **好生成/好維護**:未來加新 accent 只要沿 L 軸挑階,不用手調 hex。
+- **廣色域(P3)可選**:oklch 能表達 sRGB 以外的顏色,P3 螢幕上更飽和(選配,見 §6)。
+- **與工具鏈一致**:專案已用 Tailwind v4,其調色盤本就是 oklch —— 種入即對齊。
+
+---
+
+## 4. 遷移 Phase（零視覺變化優先)
+
+| Phase | 內容 | 風險 | 可宣稱 |
+|---|---|---|---|
+| **P1** 引入 primitive 層 | 加 `--sky-*` 等 primitive,**無消費者** | 極低（純新增） | 零視覺變化 |
+| **P2** semantic 改綁 `light-dark(primitive)` + 刪重複 override | 重寫 ~50 semantic、刪 ~150 行 | **中(核心)** | 需逐 token 雙主題 computed 值比對 |
+| **P3**（選配） 廣色域 / 新 accent | P3 opt-in、primitive 驅動的新色 | 低（加值） | 刻意增強,非零變化 |
+
+P2 是唯一有風險的一刀,靠 §5 的驗證閘守住。
+
+---
+
+## 5. 驗證閘 — 「證明零視覺變化」
+
+寫一個一次性腳本:對**每個 semantic token**,在 **dark 與 light 各自** resolve 出最終 sRGB 值,**改動前 vs 改動後**逐一比對,差異需在 oklch→sRGB 捨入 epsilon 內。作法:
+
+1. 用 headless(現有 browse/preview)載入舊 tokens.css,`getComputedStyle` 抓每個 token 在 `data-theme=dark` 與 `light` 的 resolved 值 → 存 baseline。
+2. 套 P2 後重跑,逐 token diff。任何超出 epsilon 的即為回歸,需解釋或修正。
+
+這比人工截圖可靠,且能覆蓋不在畫面上的 token。
+
+---
+
+## 6. 風險與地雷（含本 repo 特有)
+
+1. **Tailwind scanner 命名衝突（本 repo 已中過)**:`--text-*` 曾與 tailwind v4 內建 theme var 同名,害每個 PR 要重生 `tailwind.css`(見記憶 issue-120 坑 1)。新增 `--sky-*` primitive **需驗證**是否被 scanner 當 utility(tailwind 用 `--color-sky-*`,前綴不同,理論上不撞,但**務必 `npm run build:css` 後檢查 `tailwind.css` 是否變動並 commit**)。
+2. **oklch 種子的兩種取法(決策點)**:
+   - **(A) 零視覺**:把現有 hex **精確**轉 oklch(`#38bdf8` → 其 sRGB 精確 oklch)。與現況 byte-identical。
+   - **(B) 採 Tailwind v4 調色盤**:用 v4 的 oklch 值。更正統/乾淨,但 v4 對調色盤微調過,**與現有 v3 hex 有極小色偏**。
+3. **`light-dark()` 瀏覽器基準**:Baseline 2024(Chrome 123 / Safari 17.5 / Firefox 120)。Electron 43 = Chromium 130+ ✓。**server 服務的使用者瀏覽器**需確認可接受此基準(觀眾頁 viewer 面向一般大眾 —— 這是決策點)。若要保守,可對 primitive 提供 fallback 或暫留 `[data-theme]` 覆寫。
+4. **rgba 棘輪互動**:剛上的 rgba 棘輪數 style.css 等的裸 rgba。tokens.css **被 lint 排除**,故 primitive 用 oklch 不影響棘輪;semantic 改用 `var()`/`light-dark()` 反而**降低** tokens.css 外的裸值(但 tokens.css 本就不計)。無衝突。
+5. **Electron 桌面 CSS**:`child.css`/`styles.css`/`about.css` 有自己的硬編色,**未完全走 tokens**。是否納入本次是決策點(建議**先不納**,獨立 phase)。
+
+---
+
+## 7. 待決策（開工前要你拍板）
+
+| # | 決策 | 選項 | 我的傾向 |
+|---|---|---|---|
+| D1 | 主題機制 | (a) `light-dark()`（刪 ~150 行重複,需 Baseline-2024) / (b) 保留 `[data-theme]`+`@media` 但改綁 primitive | **(a)** —— 消除重複是最大收益 |
+| D2 | oklch 種子 | (A) 現有 hex 精確轉(零視覺) / (B) 採 Tailwind v4 調色盤(微色偏) | **(A)** 先零視覺遷移,(B) 當獨立「調色盤刷新」提案 |
+| D3 | 範圍 | 只 admin+viewer / 含 Electron 桌面 CSS | **只 admin+viewer**,Electron 獨立 phase |
+| D4 | P3 廣色域 | 現在 opt-in / 之後 | **之後**（P3 選配) |
+| D5 | primitive 命名 | `--sky-400`(對齊 tailwind) / `--blue-40`(中性) / `--brand-*`(語意) | **`--sky-400`** 對齊既有註解與 tailwind,遷移認知成本最低 |
+
+---
+
+## 8. 工作量與 PR 切分（估）
+
+- **PR-1（P1）**:引入 primitive 層(~7 色相 × ~8 階 ≈ 60 token)。純新增、零視覺、可獨立 merge。
+- **PR-2（P2）**:semantic 改綁 `light-dark(primitive)`、刪 `[data-theme=light]`+`@media` 重複、附 §5 逐 token 雙主題 computed 比對報告。**核心 PR**。
+- **PR-3（P3,選配)**:P3 opt-in / 新 accent / Electron 納入。
+
+---
+
+## 附錄:實測 oklch 值(自專案 `node_modules/tailwindcss/theme.css`)
+
+```
+sky-400  oklch(74.6% 0.16  232.661)   sky-600  oklch(58.8% 0.158 241.966)
+slate-100 oklch(96.8% 0.007 247.896)  slate-400 oklch(70.4% 0.04 256.788)
+slate-900 oklch(20.8% 0.042 265.755)  amber-400 oklch(82.8% 0.189 84.429)
+amber-600 oklch(66.6% 0.179 58.318)   red-500  oklch(63.7% 0.237 25.331)
+red-600  oklch(57.7% 0.245 27.325)    green-500 oklch(72.3% 0.219 149.579)
+green-600 oklch(62.7% 0.194 149.214)  cyan-400 oklch(78.9% 0.154 211.53)
+```

--- a/shared/tokens.css
+++ b/shared/tokens.css
@@ -1,4 +1,67 @@
 :root {
+  /* ══════════════════════════════════════════════════════════════════
+   * Layer 0 — Primitive palette (色彩系統 v2 · Issue #120 · Phase 1)
+   *
+   * Raw, theme-INDEPENDENT color scale. Every value is the EXACT oklch
+   * conversion of a Tailwind-v3 hex already used elsewhere in this file —
+   * round-trip verified byte-identical (the oklch string renders back to
+   * the source hex on sRGB, listed after each). This layer is purely
+   * ADDITIVE: no token consumes it yet. Phase 2 repoints the semantic
+   * tokens below to `light-dark(var(--<hue>-<lightStep>),
+   * var(--<hue>-<darkStep>))`, at which point the duplicated
+   * :root[data-theme="light"] + @media(prefers light) override blocks
+   * collapse to nothing.
+   *
+   * Only the scale steps the current system actually references are
+   * present; gaps (e.g. --slate-300) fill in when a consumer appears.
+   * Non-scale one-offs stay as direct values — they are not palette steps:
+   *   --color-danger #ff4d4f, --color-success-bright #84e100,
+   *   HUD bg #050912 / #0c1424 / #182239, --color-white #ffffff.
+   * ══════════════════════════════════════════════════════════════════ */
+  /* slate — neutral, blue-biased */
+  --slate-50:  oklch(98.42% 0.003 247.86);  /* #f8fafc */
+  --slate-100: oklch(96.83% 0.007 247.9);   /* #f1f5f9 */
+  --slate-200: oklch(92.88% 0.013 255.51);  /* #e2e8f0 */
+  --slate-400: oklch(71.07% 0.035 256.79);  /* #94a3b8 */
+  --slate-500: oklch(55.44% 0.041 257.42);  /* #64748b */
+  --slate-600: oklch(44.55% 0.037 257.28);  /* #475569 */
+  --slate-700: oklch(37.17% 0.039 257.29);  /* #334155 */
+  --slate-800: oklch(27.95% 0.037 260.03);  /* #1e293b */
+  --slate-900: oklch(20.77% 0.04 265.75);   /* #0f172a */
+  --slate-950: oklch(12.88% 0.041 264.7);   /* #020617 */
+  /* sky — primary / accent */
+  --sky-300: oklch(82.76% 0.101 230.32);    /* #7dd3fc */
+  --sky-400: oklch(75.35% 0.139 232.66);    /* #38bdf8 */
+  --sky-500: oklch(68.469% 0.1479 237.323); /* #0ea5e9 */
+  --sky-600: oklch(58.762% 0.1389 241.966); /* #0284c7 */
+  --sky-700: oklch(49.998% 0.1193 242.749); /* #0369a1 */
+  /* amber — warning */
+  --amber-400: oklch(83.686% 0.1644 84.429); /* #fbbf24 */
+  --amber-600: oklch(66.584% 0.1574 58.318); /* #d97706 */
+  /* red — error */
+  --red-300: oklch(80.77% 0.103 19.57);     /* #fca5a5 */
+  --red-400: oklch(71.06% 0.166 22.22);     /* #f87171 */
+  --red-500: oklch(63.68% 0.208 25.33);     /* #ef4444 */
+  --red-600: oklch(57.71% 0.215 27.33);     /* #dc2626 */
+  --red-700: oklch(50.542% 0.1905 27.518);  /* #b91c1c */
+  /* green — success */
+  --green-300: oklch(87.12% 0.136 154.45);  /* #86efac */
+  --green-500: oklch(72.27% 0.192 149.58);  /* #22c55e */
+  --green-600: oklch(62.71% 0.17 149.21);   /* #16a34a */
+  /* cyan — data / accent-alt */
+  --cyan-400: oklch(79.71% 0.134 211.53);   /* #22d3ee */
+  --cyan-500: oklch(71.484% 0.1257 215.221);/* #06b6d4 */
+  --cyan-600: oklch(60.89% 0.111 221.72);   /* #0891b2 */
+  /* teal — connected */
+  --teal-500: oklch(70.38% 0.123 182.5);    /* #14b8a6 */
+  --teal-600: oklch(60.022% 0.1038 184.704);/* #0d9488 */
+  /* emerald — connected-bright */
+  --emerald-500: oklch(69.59% 0.149 162.48);/* #10b981 */
+  /* blue — secondary */
+  --blue-500: oklch(62.31% 0.188 259.81);   /* #3b82f6 */
+  /* lime — success-dim */
+  --lime-700: oklch(53.222% 0.1405 131.589);/* #4d7c0f */
+
   /* Brand */
   --color-primary: #38bdf8;
   --color-primary-hover: #0ea5e9;


### PR DESCRIPTION
色彩系統 v2 提案的 **Phase 1**。決策 **D1 = `light-dark()`**、**D2 = 精確轉（零視覺）** 已定,本 PR 落地 **Layer 0 — primitive 層**。

## 做了什麼
在 `shared/tokens.css` 的 `:root` 頂端新增 **33 個主題無關的 primitive**（`--slate-*` `--sky-*` `--amber-*` `--red-*` `--green-*` `--cyan-*` `--teal-*` `--emerald-*` `--blue-*` `--lime-*`）。

- 每個值都是**現有 Tailwind-v3 hex 的精確 oklch 轉換**（**不是** Tailwind v4 的調色盤 —— 那與 v3 hex 有微差,會破壞零視覺）。
- **純新增**:目前沒有任何 token 消費它 → 本 PR **零視覺變化**。
- 只放系統實際引用的階;缺口（如 `--slate-300`）等有消費者時再補。
- 非調色盤階的一次性色不入 scale,維持直值:`--color-danger #ff4d4f`、`--color-success-bright #84e100`、HUD bg `#050912/#0c1424/#182239`、`--color-white`。

## 零視覺 — 雙重驗證
1. **Node**:每個 oklch 字串（四捨五入到實際寫入的位數）往返回原 hex **byte-identical**。
2. **瀏覽器**:canvas 把每個 primitive 畫成與來源 hex **完全相同的 sRGB bytes**（抽樣 15 個,per-channel 最大差 = **0**）。

其他確認:
- 既有 semantic 未動（`--color-primary` 仍 `#38bdf8`）。
- `npm run build:css` **不動** `tailwind.css`(`--sky-*` 不觸發 scanner,不像 `--text-*`）。
- `make lint-css` 綠。
- 無新 console 錯誤。

## 下一步(不在本 PR)
- **Phase 2**:semantic token 改綁 `light-dark(var(--x-light), var(--x-dark))`,刪除重複的 `[data-theme=light]` + `@media` override 區塊（~130 行）。附逐 token 雙主題 computed 值比對。
- Phase 3(選配):P3 廣色域 / Electron 桌面 CSS。

完整設計與 D1–D5 決策:[`docs/color-system-v2-proposal.md`](docs/color-system-v2-proposal.md)。視覺審查板另附(私有 artifact)。

Refs #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a documented, theme-independent color primitive palette using OKLCH values.
  - Introduced foundational color tokens for common hues, including slate, sky, amber, red, green, cyan, teal, emerald, blue, and lime.

- **Documentation**
  - Added a proposal outlining a future two-layer color system, migration phases, validation approach, and key design considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->