### PR TITLE
refactor(css): drop 5 empirically-vestigial !important (#120)

### DIFF
--- a/shared/hud.css
+++ b/shared/hud.css
@@ -3323,7 +3323,7 @@ html[data-theme="dark"] .admin-body .hud-hero-title {
 }
 .admin-dsp2-preview-pill-2 {
   top: 96px; left: 40px;
-  color: #FCD34D !important;
+  color: #FCD34D;
   text-shadow: 0 0 14px rgba(252, 211, 77, 0.5);
 }
 .admin-dsp2-preview-tag {
@@ -4423,16 +4423,20 @@ html[data-theme="dark"] .admin-body .hud-hero-title {
 }
 
 .admin-bc-v5__confirm-hint {
-  /* Same shape as v4 but neutral (not crimson) — pivot tones it down. */
-  background: rgba(148, 163, 184, 0.05) !important;
+  /* Same shape as v4 but neutral (not crimson) — pivot tones it down.
+   * border keeps !important: it overrides a competing border-color rule
+   * (verified — removing it flips the color). bg/color do not compete. */
+  background: rgba(148, 163, 184, 0.05);
   border: 1px solid var(--hud-line) !important;
-  color: var(--hud-text-dim, #94a3b8) !important;
+  color: var(--hud-text-dim, #94a3b8);
 }
 
 .admin-bc-v5__secondary {
-  /* Override v4 grid-cols-3 with grid-cols-2 (archive button removed) */
-  display: grid !important;
-  grid-template-columns: 1fr 1fr !important;
+  /* Override v4 grid-cols-3 with grid-cols-2 (archive button removed).
+   * hud.css loads after tailwind so equal-specificity source order already
+   * wins — !important was vestigial here (verified). */
+  display: grid;
+  grid-template-columns: 1fr 1fr;
 }
 @media (max-width: 720px) {
   .admin-bc-v5__secondary { grid-template-columns: 1fr !important; }


### PR DESCRIPTION
Issue #120 的 `!important` 瘦身。**實測後這是刻意的小切片** —— 大多數 !important 不該移除。

## 移除的 5 個(CSSOM 實測證明 vestigial)
方法:對每個 `!important` 規則,在瀏覽器 live 清掉 priority,確認匹配元素的 computed 值**不變** → 才移除。
- `.admin-dsp2-preview-pill-2` — `color`
- `.admin-bc-v5__confirm-hint` — `background`、`color`（**`border` 保留 !important**:實測移除後 border-color 會翻掉,是真競爭)
- `.admin-bc-v5__secondary` — `display`、`grid-template-columns`（蓋 tailwind grid utility;hud.css 在 tailwind 之後載入,同 specificity 已靠順序勝出 → !important 是 vestigial)

## 為何不是「全面掃 89」
實測稽核發現 89 個大多**必要**:
- ~26 個 `prefers-reduced-motion` 的 `*::after` 動畫守衛(標準實踐)
- ~18 個 `[hidden]`/`data-*` 顯示狀態切換(狀態必勝)
- 數個「候選」其實必要(如上面的 confirm-hint border)

剩下的組件狀態/mobile-sheet 案例,每個都要**在特定 admin 路由 + 視窗寬度觸發該元素狀態**才驗得了(路由無法程式化探索),per-removal choreography 不成比例、收益僅程式碼整潔 → 保留。

## 驗證
`build:css` 不動 `tailwind.css`;`make lint-css` 綠;5 個元素移除 !important 後 computed 值不變。

Refs #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved styling consistency for Admin Display Settings preview pills.
  * Refined Admin Broadcast confirmation hints and secondary controls so surrounding styles can apply correctly.
  * Preserved required visual emphasis for confirmation hint borders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->