### PR TITLE
refactor(css): drop chained-vestigial !important in mobile bc-v5 secondary (#120)

### DIFF
--- a/shared/hud.css
+++ b/shared/hud.css
@@ -4439,7 +4439,13 @@ html[data-theme="dark"] .admin-body .hud-hero-title {
   grid-template-columns: 1fr 1fr;
 }
 @media (max-width: 720px) {
-  .admin-bc-v5__secondary { grid-template-columns: 1fr !important; }
+  /* !important removed (chained consequence of the sibling desktop removal in
+   * PR 151): the desktop rule above dropped its !important, so this
+   * later-in-source, equal-specificity mobile rule now wins by source order
+   * alone. hud.css owns both rules and is the only grid-template-columns
+   * source for this selector (no style.css/tailwind competitor), so 1fr
+   * applies at max-width 720px without !important. */
+  .admin-bc-v5__secondary { grid-template-columns: 1fr; }
 }
 
 .admin-bc-v5__session-ctx {


### PR DESCRIPTION
## 什麼

移除 `shared/hud.css` mobile(≤720px)`.admin-bc-v5__secondary { grid-template-columns: 1fr !important }` 的 `!important`。

## 為什麼 — 這是 #151 的連鎖後果

#151 移除了 **desktop** `.admin-bc-v5__secondary` 那對 `!important`(實證 vestigial:hud.css 最後載入,source-order 已勝)。desktop `!important` 一旦消失,這個 mobile 規則就不再需要 `!important` 來打贏一場 `!important` 戰爭。

## 靜態證明(窮舉競爭規則)

`.admin-bc-v5__secondary` 的 `grid-template-columns` 宣告只有兩條,都在 `hud.css`:

| 規則 | 特異度 | source 位置 | `!important` |
|---|---|---|---|
| desktop `1fr 1fr` | (0,1,0) | 較前 | 無(#151 已移除) |
| mobile `1fr`(本 PR) | (0,1,0) | 較後、`@media` 內 | 移除中 |

- 元素 markup:`class="admin-bc-v4__secondary admin-bc-v5__secondary"`(`admin-broadcast.js`)——無 tailwind grid utility;v4 class 只設 `display:flex`,不設 `grid-template-columns`。
- `style.css` **無** `.admin-bc-v5__secondary` 規則(hud.css 是唯一 owner)。
- 載入序:`tailwind.css` → `style.css` → **`hud.css`(最後)**。

∴ 在 ≤720px 時,mobile 規則同特異度、source 較後 → **無 `!important` 也以 source-order 勝出**,計算值不變(仍為 `1fr`)。無更高特異度或更後的競爭者。

## 驗證

- `make lint-css` ✅(無新增 hex/px/rgba)
- 靜態 source-order 證明如上(與 #151 對其 sibling 採用的同一套推理)
- ⚠️ live mobile-width 截圖未附:本 session 的 sandbox 瀏覽器面板不可用(http.server 無法 bind、file:// 導覽逾時,與 #150 同一限制)。合併前若要 belt-and-suspenders,在 admin `#/overlay`(廣播頁)縮到 ≤720px 目視 `.admin-bc-v5__secondary` 仍為單欄即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
