### PR TITLE
fix(deps): bump brace-expansion to patch CVE-2026-13149 (high)

### DIFF
--- a/danmu-desktop/package-lock.json
+++ b/danmu-desktop/package-lock.json
@@ -4846,9 +4846,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7021,9 +7021,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9131,6 +9131,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -9618,9 +9619,9 @@
       }
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10080,9 +10081,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What

Bumps the transitive **dev-scope** dependency `brace-expansion` in `danmu-desktop/package-lock.json` to close two high-severity Dependabot alerts.

| Alert | Advisory | Vulnerable range | Fix |
|---|---|---|---|
| #106 | GHSA-3jxr-9vmj-r5cp / CVE-2026-13149 | `< 1.1.16` | `node_modules/brace-expansion` 1.1.13 → **1.1.16** |
| #107 | GHSA-3jxr-9vmj-r5cp / CVE-2026-13149 | `>= 2.0.0, < 2.1.2` | `@jest/reporters`, `jest-config`, `jest-runtime` 2.1.0 → **2.1.2** |

ReDoS (exponential-time expansion of consecutive non-expanding `{}` groups), high severity.

## Why lockfile-only

Both patched versions fall within the existing parent semver ranges (`^1.1.7` / `^2.0.2`), so `package.json` is untouched — this is a pure `npm update brace-expansion --package-lock-only` change. All affected paths are `dev` dependencies (jest / electron-builder build tooling); nothing ships in the Electron app runtime.

## Verification

- `npm ci` installs cleanly; no vulnerable `brace-expansion` versions remain (all instances now 1.1.16 / 2.1.2 / 5.0.8).
- Electron jest: **525/525 passed** (32 suites).

## Out of scope (noted, not fixed here)

A separate advisory **GHSA-mh99-v99m-4gvg** (unbounded expansion → OOM, `<= 5.0.7`, patched 5.0.8) is surfaced by `npm audit` but is **not** a Dependabot alert on this repo. Fixing it requires `npm audit fix --force` upgrading electron-builder to 25.1.8 (breaking) — to be evaluated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)