### PR TITLE
fix(electron): declare tray idle/overlay let vars before first use (TDZ)

### DIFF
--- a/danmu-desktop/main.js
+++ b/danmu-desktop/main.js
@@ -117,6 +117,13 @@ app.whenReady().then(() => {
 
   let trayStatusText = "⊘ 未連線";
   let trayServerUrl = "";
+  // Overlay state read by rebuildTrayMenu() below. Declared here — BEFORE the
+  // first rebuildTrayMenu() call — because `let` is in its temporal dead zone
+  // until its declaration executes; the first call used to run before these
+  // and threw "Cannot access '…' before initialization" as an unhandled
+  // rejection at startup.
+  let idleActive = false;
+  let overlayVisible = true; // tracks show/hide (not create/destroy)
 
   // Broadcast an overlay-idle-toggle message to every live child window.
   // mode: 'show' | 'hide' | 'toggle'
@@ -268,9 +275,6 @@ app.whenReady().then(() => {
 
   rebuildTrayMenu();
   tray.setToolTip("Danmu Desktop");
-
-  let idleActive = false;
-  let overlayVisible = true; // tracks show/hide (not create/destroy)
 
   // Reset overlayVisible when overlay windows are created or destroyed
   // externally (e.g. from renderer "Start" / "Stop" buttons via ipc-handlers).


### PR DESCRIPTION
## 症狀
Electron 主進程啟動時噴 non-fatal 警告:
```
ReferenceError: Cannot access '_' before initialization  (at main.bundle.js, minified)
```
App 照常運作,但每次啟動都拋一個 unhandled rejection。

## 根因（純宣告順序 bug,非 bundler/minify 造成）
`rebuildTrayMenu()`(hoisted `function`)的**第一次呼叫**發生在 `let idleActive` / `let overlayVisible` **宣告之前**。而它建的 tray 選單模板會讀這兩個變數(`checked: hasOverlay && overlayVisible`、`checked: idleActive && hasOverlay`)。`let` 在宣告執行前處於 temporal dead zone → 第一次呼叫拋 TDZ。

因為發生在 async 啟動路徑 → 變成 unhandled rejection(非硬崩),視窗照常渲染、之後 IPC 觸發的 rebuild 也正常(那時變數已初始化)—— 所以一直沒被發現。

## 修法
把兩個 `let` 移到 `trayStatusText`/`trayServerUrl` 旁邊、第一次呼叫之前。**同 scope、同引用,零行為變化**,只是消掉啟動時的 TDZ rejection。

## 診斷方式
壓縮碼定位 `_` → 對回原始碼 `idleActive`(line 272)/`overlayVisible`(273)在 `rebuildTrayMenu()` 呼叫(269)之後宣告。依賴圖確認**無循環依賴**,排除 scope-hoisting 假設。

## 驗證
- 重建 bundle 後啟動 → log **無 TDZ / unhandled rejection**
- jest **525/525** 全綠

Refs #120 系列後續(此為既有 bug,非該系列引入)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a startup error that could prevent the tray overlay from loading correctly.
  * Improved tray menu initialization and overlay status updates for a more reliable launch experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->