### PR TITLE
refactor(css): fold 28 exact-match bare rgba into tokens in Electron desktop CSS (#120)

### DIFF
--- a/danmu-desktop/about.css
+++ b/danmu-desktop/about.css
@@ -65,7 +65,7 @@ body {
   margin-top: 1.5rem;
   padding: 0.5rem 2rem;
   background: rgba(30, 41, 59, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
   border-radius: 0.5rem;
   color: var(--color-text-primary);
   font-family: inherit;

--- a/danmu-desktop/child.css
+++ b/danmu-desktop/child.css
@@ -109,7 +109,7 @@ img{
   line-height: 1;
   filter:
     drop-shadow(0 10px 15px rgba(0, 0, 0, 0.45))
-    drop-shadow(0 4px 6px rgba(0, 0, 0, 0.3));
+    drop-shadow(0 4px 6px var(--shadow-base, rgba(0, 0, 0, 0.3)));
 }
 
 .overlay-idle-subtitle {
@@ -129,8 +129,8 @@ img{
   gap: 16px;
   padding: 10px 20px;
   border-radius: var(--radius-pill);
-  border: 1px solid rgba(56, 189, 248, 0.45);
-  background: rgba(56, 189, 248, 0.12);
+  border: 1px solid var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
+  background: var(--hud-cyan-soft, rgba(56, 189, 248, 0.12));
 }
 
 .overlay-idle-chip-dot {

--- a/danmu-desktop/styles.css
+++ b/danmu-desktop/styles.css
@@ -292,7 +292,7 @@ details summary svg {
   padding: 0 12px;
   height: 36px;
   background: rgba(15, 23, 42, 0.92);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  border-bottom: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   font-family: "JetBrains Mono", ui-monospace, monospace;
@@ -379,8 +379,8 @@ body[data-os="mac"] .client-titlebar {
   gap: 5px;
   padding: 3px 9px;
   border-radius: var(--radius-pill);
-  border: 1px solid rgba(56, 189, 248, 0.45);
-  background: rgba(56, 189, 248, 0.12);
+  border: 1px solid var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
+  background: var(--hud-cyan-soft, rgba(56, 189, 248, 0.12));
   color: var(--color-primary);
   font-family: "JetBrains Mono", ui-monospace, monospace;
   font-size: 9px;
@@ -461,7 +461,7 @@ body[data-os="mac"] .client-titlebar {
   padding: 10px 12px;
   border-radius: var(--radius-md-sm);
   background: rgba(15, 23, 42, 0.55);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   font-size: 12px;
   line-height: 1.6;
   color: rgba(241, 245, 249, 0.85);
@@ -485,7 +485,7 @@ body[data-os="mac"] .client-titlebar {
   flex: 1 1 auto;
   height: 6px;
   border-radius: var(--radius-pill);
-  background: rgba(148, 163, 184, 0.18);
+  background: var(--hud-line, rgba(148, 163, 184, 0.18));
   overflow: hidden;
 }
 
@@ -550,7 +550,7 @@ body[data-os="mac"] .client-titlebar {
 .client-sidebar {
   flex: 0 0 168px;
   background: rgba(15, 23, 42, 0.85);
-  border-right: 1px solid rgba(148, 163, 184, 0.18);
+  border-right: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   padding: 10px;
@@ -590,7 +590,7 @@ body[data-os="mac"] .client-titlebar {
 }
 
 .client-nav-btn.is-active {
-  background: rgba(56, 189, 248, 0.12);
+  background: var(--hud-cyan-soft, rgba(56, 189, 248, 0.12));
   color: var(--color-primary);
 }
 
@@ -703,7 +703,7 @@ body[data-os="mac"] .client-titlebar {
 /* Shortcuts list */
 .client-keys-card {
   background: rgba(15, 23, 42, 0.55);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   border-radius: var(--radius-md);
   padding: 14px;
   backdrop-filter: blur(8px);
@@ -726,9 +726,9 @@ body[data-os="mac"] .client-titlebar {
 
 .client-keys-row .kbd {
   padding: 4px 10px;
-  border: 1px solid rgba(56, 189, 248, 0.45);
+  border: 1px solid var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   border-radius: var(--radius-sm);
-  background: rgba(56, 189, 248, 0.12);
+  background: var(--hud-cyan-soft, rgba(56, 189, 248, 0.12));
   font-family: "JetBrains Mono", ui-monospace, monospace;
   font-size: 12px;
   letter-spacing: 1px;
@@ -749,7 +749,7 @@ body[data-os="mac"] .client-titlebar {
   align-items: center;
   gap: 14px;
   padding: 16px;
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   border-radius: var(--radius-md);
   background: rgba(15, 23, 42, 0.5);
   margin-bottom: 14px;
@@ -789,7 +789,7 @@ body[data-os="mac"] .client-titlebar {
 .client-update-check-btn {
   padding: 8px 16px;
   background: transparent;
-  border: 1px solid rgba(56, 189, 248, 0.45);
+  border: 1px solid var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   border-radius: var(--radius-md-sm);
   color: var(--color-primary);
   font-family: "JetBrains Mono", ui-monospace, monospace;
@@ -799,13 +799,13 @@ body[data-os="mac"] .client-titlebar {
   transition: background var(--motion-fast) ease, color var(--motion-fast) ease;
 }
 .client-update-check-btn:hover {
-  background: rgba(56, 189, 248, 0.12);
+  background: var(--hud-cyan-soft, rgba(56, 189, 248, 0.12));
   color: var(--color-text-primary);
 }
 
 .client-update-prefs {
   padding: 14px 16px;
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   border-radius: var(--radius-md);
   background: rgba(15, 23, 42, 0.5);
   margin-bottom: 14px;
@@ -841,7 +841,7 @@ body[data-os="mac"] .client-titlebar {
 
 .client-update-changelog {
   padding: 14px 16px;
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   border-radius: var(--radius-md);
   background: rgba(15, 23, 42, 0.5);
 }
@@ -877,7 +877,7 @@ body[data-os="mac"] .client-titlebar {
 /* About card */
 .client-about-card {
   background: rgba(15, 23, 42, 0.55);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   border-radius: var(--radius-md);
   padding: 20px;
   display: flex;
@@ -953,7 +953,7 @@ body[data-os="mac"] .client-titlebar {
 .client-about-desc {
   padding: 14px;
   border-radius: var(--radius-md);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   background: rgba(15, 23, 42, 0.45);
   font-size: 12px;
   line-height: 1.7;
@@ -986,7 +986,7 @@ body[data-os="mac"] .client-titlebar {
 .client-conn-card {
   padding: 14px;
   border-radius: var(--radius-md);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   background: rgba(15, 23, 42, 0.55);
   backdrop-filter: blur(8px);
 }
@@ -1063,7 +1063,7 @@ body[data-os="mac"] .client-titlebar {
   padding: 10px 12px;
   background: rgba(15, 23, 42, 0.4);
   border-radius: var(--radius-md-sm);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   cursor: text;
   transition: border-color var(--motion-fast) ease, background var(--motion-fast) ease;
 }
@@ -1166,7 +1166,7 @@ body[data-os="mac"] .client-titlebar {
   padding: 5px 14px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--color-primary);
-  background: rgba(56, 189, 248, 0.12);
+  background: var(--hud-cyan-soft, rgba(56, 189, 248, 0.12));
   color: var(--color-primary);
   font-family: ui-sans-serif, system-ui, "PingFang TC", sans-serif;
   font-size: 11px;
@@ -1249,7 +1249,7 @@ body[data-os="mac"] .client-titlebar {
   padding: 8px 12px;
   background: rgba(15, 23, 42, 0.4);
   border-radius: var(--radius-md-sm);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
 }
 
 .client-conn-last-addr {
@@ -1493,7 +1493,7 @@ body[data-os="mac"] .client-titlebar {
 .client-overlay-card {
   padding: 14px;
   border-radius: var(--radius-md);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   background: rgba(15, 23, 42, 0.55);
   backdrop-filter: blur(8px);
   display: flex;
@@ -1634,7 +1634,7 @@ body[data-os="mac"] .client-titlebar {
 
 .client-screen-chip.is-active {
   border-color: var(--color-primary);
-  background: rgba(56, 189, 248, 0.12);
+  background: var(--hud-cyan-soft, rgba(56, 189, 248, 0.12));
 }
 
 .client-screen-chip.is-active .box {
@@ -1737,7 +1737,7 @@ body[data-os="mac"] .client-titlebar {
   position: fixed;
   inset: 0;
   z-index: 9000;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--color-overlay, rgba(0, 0, 0, 0.6));
   display: flex;
   align-items: center;
   justify-content: center;

--- a/scripts/css-token-baseline.json
+++ b/scripts/css-token-baseline.json
@@ -2,17 +2,17 @@
   "danmu-desktop/about.css": {
     "hex": 2,
     "gridPx": 0,
-    "rgba": 4
+    "rgba": 3
   },
   "danmu-desktop/child.css": {
     "hex": 13,
     "gridPx": 4,
-    "rgba": 10
+    "rgba": 7
   },
   "danmu-desktop/styles.css": {
     "hex": 19,
     "gridPx": 103,
-    "rgba": 161
+    "rgba": 137
   },
   "danmu-desktop/tailwind-input.css": {
     "hex": 0,


### PR DESCRIPTION
## Summary
- Color system v2 **Phase 3（Electron 桌面色）第一批**：把 Electron 三個恆暗面（`styles.css` / `child.css` / `about.css`）中**值精確等於 token** 的裸 `rgba()` 折進 repo 慣例的 `var(--token, rgba-fallback)` 形式，共 **28 處**，零視覺變化。
- rgba 棘輪同步下修：`styles.css` 161→137、`child.css` 10→7、`about.css` 4→3。

## 對照表
| 原 literal | Token | 處數 |
|---|---|---|
| `rgba(148,163,184,.18)` border | `--color-border-soft` | 13 |
| `rgba(148,163,184,.18)` track fill | `--hud-line` | 1 |
| `rgba(56,189,248,.45)` border | `--hud-cyan-line` | 4 |
| `rgba(56,189,248,.12)` fill | `--hud-cyan-soft` | 7 |
| `rgba(0,0,0,.6)` backdrop | `--color-overlay` | 1 |
| `rgba(0,0,0,.3)` drop-shadow | `--shadow-base` | 1 |
| `rgba(255,255,255,.1)` border | `--color-border` | 1 |

## 零視覺證明
1. 三檔第一行都 `@import "./tokens.css"`；`tokens.css:8` 設 `:root{color-scheme:dark}`，且三面 CSS 鏈**無任何 light 覆寫**（`hud.css:305` 的 light media 塊只動 `.admin-body .hud-hero-title`，Electron 視窗無 `.admin-body`）→ `light-dark()` token 一律解析 dark 臂。
2. In-browser computed-style probe：7 個 token 的解析值與原 literal **byte-identical MATCH**，且在模擬 `prefers-color-scheme: light` 下仍全 MATCH（顯式 `color-scheme:dark` 勝出）。

## 刻意不折
- sky@0.4 hover/state border（值同 `--glow-primary` 但語意是 glow 非 border）
- note panel / close-btn 背景（值同 `--color-bg-input(-disabled)` 但語意不合）
- 裝飾 grid gradient（沿用 PR 148 排除原則）與無精確 token 的 literal

## 驗證
- `node scripts/check-css-tokens.mjs` ✓（棘輪通過後 `--update` 下修 baseline）
- Electron jest：**525 passed / 32 suites**
- `npx webpack`：main / renderer / preload 三 bundle 編譯成功
- 未引入任何 `var(--text-*)` → 不觸發 tailwind scanner，無需重生 tailwind.css

Refs #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated desktop interface styling to use theme-aware colors and shadows.
  * Improved consistency across panels, buttons, badges, overlays, connection controls, and active states.
  * Preserved fallback colors for reliable appearance across supported themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->