### PR TITLE
refactor(css): fold 84 exact-match grid px into space/text tokens in Electron desktop CSS (#120)

### DIFF
--- a/danmu-desktop/child.css
+++ b/danmu-desktop/child.css
@@ -126,7 +126,7 @@ img{
   margin-top: 26px;
   display: inline-flex;
   align-items: center;
-  gap: 16px;
+  gap: var(--space-4);
   padding: 10px 20px;
   border-radius: var(--radius-pill);
   border: 1px solid var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
@@ -145,7 +145,7 @@ img{
 
 .overlay-idle-chip-label {
   font-family: "IBM Plex Mono", ui-monospace, monospace;
-  font-size: 12px;
+  font-size: var(--text-xs);
   letter-spacing: 2px;
   color: var(--color-primary, #38bdf8);
   text-transform: uppercase;
@@ -178,7 +178,7 @@ img{
 }
 
 .overlay-idle-url {
-  margin-top: 12px;
+  margin-top: var(--space-3);
   font-family: "IBM Plex Mono", ui-monospace, monospace;
   font-size: 11px;
   letter-spacing: 2px;

--- a/danmu-desktop/styles.css
+++ b/danmu-desktop/styles.css
@@ -288,8 +288,8 @@ details summary svg {
   z-index: 20;
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 0 12px;
+  gap: var(--space-2);
+  padding: 0 var(--space-3);
   height: 36px;
   background: rgba(15, 23, 42, 0.92);
   border-bottom: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
@@ -323,11 +323,11 @@ body[data-os="mac"] .client-titlebar {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .client-titlebar-label {
-  font-size: 12px;
+  font-size: var(--text-xs);
   letter-spacing: 1px;
   color: rgba(148, 163, 184, 0.9);
 }
@@ -424,14 +424,14 @@ body[data-os="mac"] .client-titlebar {
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .client-update-card .title-row {
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
   width: 100%;
 }
 
@@ -444,7 +444,7 @@ body[data-os="mac"] .client-titlebar {
 }
 
 .client-update-card .title {
-  font-size: 14px;
+  font-size: var(--text-sm);
   font-weight: 600;
   color: rgba(241, 245, 249, 0.95);
 }
@@ -462,7 +462,7 @@ body[data-os="mac"] .client-titlebar {
   border-radius: var(--radius-md-sm);
   background: rgba(15, 23, 42, 0.55);
   border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
-  font-size: 12px;
+  font-size: var(--text-xs);
   line-height: 1.6;
   color: rgba(241, 245, 249, 0.85);
   white-space: pre-wrap;
@@ -507,17 +507,17 @@ body[data-os="mac"] .client-titlebar {
 }
 
 .client-update-card .error {
-  margin-top: 8px;
-  font-size: 12px;
+  margin-top: var(--space-2);
+  font-size: var(--text-xs);
   color: var(--color-error-lighter);
 }
 
 .client-update-card .error[hidden] { display: none !important; }
 
 .client-update-card .actions {
-  margin-top: 12px;
+  margin-top: var(--space-3);
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   flex-wrap: wrap;
 }
 
@@ -597,7 +597,7 @@ body[data-os="mac"] .client-titlebar {
 .client-nav-icon {
   width: 14px;
   text-align: center;
-  font-size: 14px;
+  font-size: var(--text-sm);
   flex-shrink: 0;
 }
 
@@ -609,7 +609,7 @@ body[data-os="mac"] .client-titlebar {
 }
 
 .client-nav-label .zh {
-  font-size: 12px;
+  font-size: var(--text-xs);
   font-weight: 500;
 }
 
@@ -650,7 +650,7 @@ body[data-os="mac"] .client-titlebar {
   height: 6px;
   border-radius: 50%;
   background: var(--color-success-light);
-  margin-right: 4px;
+  margin-right: var(--space-1);
   vertical-align: 0;
   box-shadow: 0 0 6px rgba(134, 239, 172, 0.5);
 }
@@ -666,7 +666,7 @@ body[data-os="mac"] .client-titlebar {
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
   margin-bottom: 14px;
 }
 
@@ -686,7 +686,7 @@ body[data-os="mac"] .client-titlebar {
 }
 
 .client-section-title {
-  font-size: 18px;
+  font-size: var(--text-lg);
   font-weight: 600;
   letter-spacing: -0.2px;
   color: rgba(241, 245, 249, 0.95);
@@ -730,7 +730,7 @@ body[data-os="mac"] .client-titlebar {
   border-radius: var(--radius-sm);
   background: var(--hud-cyan-soft, rgba(56, 189, 248, 0.12));
   font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 12px;
+  font-size: var(--text-xs);
   letter-spacing: 1px;
   color: var(--color-primary);
 }
@@ -748,7 +748,7 @@ body[data-os="mac"] .client-titlebar {
   display: flex;
   align-items: center;
   gap: 14px;
-  padding: 16px;
+  padding: var(--space-4);
   border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   border-radius: var(--radius-md);
   background: rgba(15, 23, 42, 0.5);
@@ -774,7 +774,7 @@ body[data-os="mac"] .client-titlebar {
 }
 .client-update-status-body { flex: 1; min-width: 0; }
 .client-update-status-title {
-  font-size: 14px;
+  font-size: var(--text-sm);
   font-weight: 600;
   color: rgba(241, 245, 249, 0.95);
 }
@@ -787,7 +787,7 @@ body[data-os="mac"] .client-titlebar {
 }
 .client-update-status-meta .sep { margin: 0 6px; opacity: 0.5; }
 .client-update-check-btn {
-  padding: 8px 16px;
+  padding: var(--space-2) var(--space-4);
   background: transparent;
   border: 1px solid var(--hud-cyan-line, rgba(56, 189, 248, 0.45));
   border-radius: var(--radius-md-sm);
@@ -822,7 +822,7 @@ body[data-os="mac"] .client-titlebar {
   display: flex;
   align-items: flex-start;
   gap: 10px;
-  padding: 8px 0;
+  padding: var(--space-2) 0;
   cursor: pointer;
 }
 .client-update-pref input[type="checkbox"] {
@@ -848,7 +848,7 @@ body[data-os="mac"] .client-titlebar {
 .client-update-changelog-head {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   margin-bottom: 10px;
 }
 .client-update-changelog-kicker {
@@ -868,8 +868,8 @@ body[data-os="mac"] .client-titlebar {
 }
 .client-update-changelog-link:hover { color: var(--color-primary-light); }
 .client-update-changelog-empty {
-  padding: 12px 0;
-  font-size: 12px;
+  padding: var(--space-3) 0;
+  font-size: var(--text-xs);
   color: rgba(148, 163, 184, 0.7);
   text-align: center;
 }
@@ -879,9 +879,9 @@ body[data-os="mac"] .client-titlebar {
   background: rgba(15, 23, 42, 0.55);
   border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   border-radius: var(--radius-md);
-  padding: 20px;
+  padding: var(--space-5);
   display: flex;
-  gap: 16px;
+  gap: var(--space-4);
   align-items: center;
   margin-bottom: 14px;
   backdrop-filter: blur(8px);
@@ -896,7 +896,7 @@ body[data-os="mac"] .client-titlebar {
 }
 
 .client-about-body .title {
-  font-size: 16px;
+  font-size: var(--text-base);
   font-weight: 600;
   color: rgba(241, 245, 249, 0.95);
 }
@@ -910,7 +910,7 @@ body[data-os="mac"] .client-titlebar {
 }
 
 .client-about-body .status {
-  margin-top: 4px;
+  margin-top: var(--space-1);
   font-family: "JetBrains Mono", ui-monospace, monospace;
   font-size: 11px;
   letter-spacing: 1px;
@@ -923,7 +923,7 @@ body[data-os="mac"] .client-titlebar {
   height: 6px;
   border-radius: 50%;
   background: var(--color-success-light);
-  margin-right: 4px;
+  margin-right: var(--space-1);
   vertical-align: 0;
   box-shadow: 0 0 6px rgba(134, 239, 172, 0.5);
 }
@@ -939,7 +939,7 @@ body[data-os="mac"] .client-titlebar {
   border: 1px solid rgba(148, 163, 184, 0.25);
   background: transparent;
   color: rgba(241, 245, 249, 0.9);
-  font-size: 12px;
+  font-size: var(--text-xs);
   font-weight: 500;
   transition: border-color var(--motion-fast) ease, color var(--motion-fast) ease, background var(--motion-fast) ease;
 }
@@ -955,7 +955,7 @@ body[data-os="mac"] .client-titlebar {
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
   background: rgba(15, 23, 42, 0.45);
-  font-size: 12px;
+  font-size: var(--text-xs);
   line-height: 1.7;
   color: rgba(241, 245, 249, 0.85);
   backdrop-filter: blur(6px);
@@ -1009,7 +1009,7 @@ body[data-os="mac"] .client-titlebar {
 }
 
 .client-conn-meta {
-  margin-top: 4px;
+  margin-top: var(--space-1);
   font-family: "JetBrains Mono", ui-monospace, monospace;
   font-size: 10px;
   letter-spacing: 0.5px;
@@ -1024,7 +1024,7 @@ body[data-os="mac"] .client-titlebar {
 .client-conn-meta b { font-weight: 500; color: rgba(241, 245, 249, 0.95); }
 
 .client-conn-note {
-  margin-top: 4px;
+  margin-top: var(--space-1);
   font-size: 11px;
   line-height: 1.5;
   color: rgba(148, 163, 184, 0.8);
@@ -1044,7 +1044,7 @@ body[data-os="mac"] .client-titlebar {
 .client-conn-card-head {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .client-conn-card-meta {
@@ -1056,10 +1056,10 @@ body[data-os="mac"] .client-titlebar {
 }
 
 .client-conn-host-row {
-  margin-top: 8px;
+  margin-top: var(--space-2);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 10px 12px;
   background: rgba(15, 23, 42, 0.4);
   border-radius: var(--radius-md-sm);
@@ -1109,10 +1109,10 @@ body[data-os="mac"] .client-titlebar {
 }
 
 .client-conn-preview-row {
-  margin-top: 8px;
+  margin-top: var(--space-2);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .client-conn-preview {
@@ -1183,7 +1183,7 @@ body[data-os="mac"] .client-titlebar {
 [data-conn-edit][hidden] { display: none; }
 
 .client-conn-edit-label {
-  margin-top: 8px;
+  margin-top: var(--space-2);
   font-family: "JetBrains Mono", ui-monospace, monospace;
   font-size: 9px;
   letter-spacing: 1px;
@@ -1228,7 +1228,7 @@ body[data-os="mac"] .client-titlebar {
 .client-conn-edit-save:hover { background: var(--color-primary-light); }
 
 .client-conn-edit-cancel {
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-md-sm);
   border: 1px solid rgba(148, 163, 184, 0.25);
   background: transparent;
@@ -1245,8 +1245,8 @@ body[data-os="mac"] .client-titlebar {
   margin-top: 10px;
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
   background: rgba(15, 23, 42, 0.4);
   border-radius: var(--radius-md-sm);
   border: 1px solid var(--color-border-soft, rgba(148, 163, 184, 0.18));
@@ -1255,7 +1255,7 @@ body[data-os="mac"] .client-titlebar {
 .client-conn-last-addr {
   flex: 1;
   font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 12px;
+  font-size: var(--text-xs);
   color: rgba(241, 245, 249, 0.95);
   word-break: break-all;
 }
@@ -1268,7 +1268,7 @@ body[data-os="mac"] .client-titlebar {
 }
 
 .client-conn-hint {
-  margin-top: 8px;
+  margin-top: var(--space-2);
   font-family: "JetBrains Mono", ui-monospace, monospace;
   font-size: 9px;
   letter-spacing: 0.3px;
@@ -1297,7 +1297,7 @@ body[data-os="mac"] .client-titlebar {
 .client-conn-auth-summary {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   cursor: pointer;
   font-size: 13px;
   font-weight: 500;
@@ -1319,7 +1319,7 @@ body[data-os="mac"] .client-titlebar {
 
 .client-conn-auth-summary::before {
   content: "▸";
-  font-size: 12px;
+  font-size: var(--text-xs);
   color: rgba(148, 163, 184, 0.8);
   transition: transform var(--motion-fast) ease;
 }
@@ -1392,9 +1392,9 @@ body[data-os="mac"] .client-titlebar {
 }
 
 .client-conn-flow-stats {
-  margin-top: 8px;
+  margin-top: var(--space-2);
   display: flex;
-  gap: 20px;
+  gap: var(--space-5);
   font-family: "JetBrains Mono", ui-monospace, monospace;
   font-size: 10px;
   letter-spacing: 0.5px;
@@ -1420,7 +1420,7 @@ body[data-os="mac"] .client-titlebar {
   display: flex;
   align-items: center;
   gap: 10px;
-  margin-bottom: 12px;
+  margin-bottom: var(--space-3);
 }
 
 .client-conn-edit-head .client-mini-btn { margin-left: auto; }
@@ -1428,7 +1428,7 @@ body[data-os="mac"] .client-titlebar {
 .client-conn-edit-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 @media (max-width: 640px) {
@@ -1439,7 +1439,7 @@ body[data-os="mac"] .client-titlebar {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  font-size: 12px;
+  font-size: var(--text-xs);
   color: rgba(241, 245, 249, 0.9);
 }
 
@@ -1458,7 +1458,7 @@ body[data-os="mac"] .client-titlebar {
   border: 1px solid rgba(148, 163, 184, 0.2);
   background: rgba(15, 23, 42, 0.6);
   color: rgba(241, 245, 249, 0.95);
-  font-size: 12px;
+  font-size: var(--text-xs);
   outline: none;
   transition: border-color var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
 }
@@ -1473,8 +1473,8 @@ body[data-os="mac"] .client-titlebar {
   grid-column: span 2;
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 12px;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
   color: rgba(241, 245, 249, 0.9);
   cursor: pointer;
 }
@@ -1524,7 +1524,7 @@ body[data-os="mac"] .client-titlebar {
   background: var(--color-primary);
   color: var(--color-bg-deep, #020617);
   cursor: pointer;
-  font-size: 12px;
+  font-size: var(--text-xs);
   font-weight: 700;
   letter-spacing: 0.2px;
   transition: background var(--motion-fast) ease, border-color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, transform var(--motion-fast) ease;
@@ -1563,7 +1563,7 @@ body[data-os="mac"] .client-titlebar {
 }
 
 .client-overlay-screens .head .label {
-  font-size: 12px;
+  font-size: var(--text-xs);
   font-weight: 500;
   color: rgba(241, 245, 249, 0.9);
 }
@@ -1598,8 +1598,8 @@ body[data-os="mac"] .client-titlebar {
 .client-screen-chip .head {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 4px;
+  gap: var(--space-2);
+  margin-bottom: var(--space-1);
 }
 
 .client-screen-chip .box {
@@ -1612,7 +1612,7 @@ body[data-os="mac"] .client-titlebar {
 }
 
 .client-screen-chip .name {
-  font-size: 12px;
+  font-size: var(--text-xs);
   font-weight: 500;
   color: rgba(241, 245, 249, 0.9);
 }
@@ -1646,12 +1646,12 @@ body[data-os="mac"] .client-titlebar {
 .client-screen-chip.is-active .check { opacity: 1; }
 
 .client-overlay-sync {
-  margin-top: 12px;
+  margin-top: var(--space-3);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   color: rgba(203, 213, 225, 0.86);
-  font-size: 12px;
+  font-size: var(--text-xs);
 }
 
 .client-overlay-sync input {
@@ -1661,7 +1661,7 @@ body[data-os="mac"] .client-titlebar {
 /* Overlay action buttons (secondary actions only; start/stop uses the primary button) */
 .client-overlay-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   flex-wrap: wrap;
   margin-bottom: 14px;
 }
@@ -1673,7 +1673,7 @@ body[data-os="mac"] .client-titlebar {
   background: transparent;
   color: rgba(241, 245, 249, 0.9);
   cursor: pointer;
-  font-size: 12px;
+  font-size: var(--text-xs);
   font-weight: 500;
   transition: border-color var(--motion-fast) ease, background var(--motion-fast) ease, color var(--motion-fast) ease;
   display: inline-flex;
@@ -1702,7 +1702,7 @@ body[data-os="mac"] .client-titlebar {
 
 /* NOTE panel (prototype OverlaySection:239) */
 .client-overlay-note {
-  padding: 12px;
+  padding: var(--space-3);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-md-sm);
   font-size: 11px;
@@ -1721,16 +1721,16 @@ body[data-os="mac"] .client-titlebar {
 }
 
 .client-overlay-note p {
-  margin: 4px 0 0;
+  margin: var(--space-1) 0 0;
 }
 
 .client-overlay-note b { color: rgba(241, 245, 249, 0.95); font-weight: 600; }
 
 /* ── Window Picker (#117) ─────────────────────────────────────────── */
 .client-window-picker-btn {
-  margin-top: 8px;
+  margin-top: var(--space-2);
   width: 100%;
-  font-size: 12px;
+  font-size: var(--text-xs);
 }
 
 .wp-backdrop {
@@ -1766,7 +1766,7 @@ body[data-os="mac"] .client-titlebar {
 }
 
 .wp-title {
-  font-size: 16px;
+  font-size: var(--text-base);
   font-weight: 700;
   color: var(--color-text-bright, #f8fafc);
   margin: 0;
@@ -1778,7 +1778,7 @@ body[data-os="mac"] .client-titlebar {
   color: var(--color-text-muted, #64748b);
   font-size: 22px;
   cursor: pointer;
-  padding: 4px 8px;
+  padding: var(--space-1) var(--space-2);
   border-radius: var(--radius-md-sm);
   line-height: 1;
 }
@@ -1787,12 +1787,12 @@ body[data-os="mac"] .client-titlebar {
 .wp-tabs {
   display: flex;
   gap: 2px;
-  padding: 8px 16px 0;
+  padding: var(--space-2) var(--space-4) 0;
 }
 
 .wp-tab {
   flex: 1;
-  padding: 8px;
+  padding: var(--space-2);
   border: none;
   border-radius: var(--radius-md) var(--radius-md) 0 0;
   background: transparent;
@@ -1812,7 +1812,7 @@ body[data-os="mac"] .client-titlebar {
 .wp-grid {
   flex: 1;
   overflow-y: auto;
-  padding: 12px 16px;
+  padding: var(--space-3) var(--space-4);
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
   gap: 10px;
@@ -1885,7 +1885,7 @@ body[data-os="mac"] .client-titlebar {
 }
 
 .wp-hint {
-  font-size: 12px;
+  font-size: var(--text-xs);
   color: var(--color-text-muted, #64748b);
   transition: color var(--motion-normal);
 }

--- a/scripts/css-token-baseline.json
+++ b/scripts/css-token-baseline.json
@@ -6,12 +6,12 @@
   },
   "danmu-desktop/child.css": {
     "hex": 13,
-    "gridPx": 4,
+    "gridPx": 1,
     "rgba": 7
   },
   "danmu-desktop/styles.css": {
     "hex": 19,
-    "gridPx": 103,
+    "gridPx": 22,
     "rgba": 137
   },
   "danmu-desktop/tailwind-input.css": {


### PR DESCRIPTION
## Summary
Color system v2 **Phase 3 第二批**（接續 #155）。沿用 #144 建立的 exact-match 紀律：**px 值精確等於 token** 者才改成 `var(--token)`，共 **84 個 gridPx**。

- **styles.css**：26 個 `font-size`（12/14/16/18/20px → `--text-xs/sm/base/lg/xl`）+ 52 個間距宣告 / 55 terms（4/8/12/16/20px → `--space-1`…`--space-5`）
- **child.css**：1 個 font-size + 2 個間距 terms
- gridPx 棘輪：`styles.css` 103→22、`child.css` 4→1

## 轉換規則
只轉「**每一項**都是 token px 或裸 `0`」的宣告。**22 個混合 shorthand 刻意不動**（`padding: 10px 12px`、`14px 16px`、`40px 16px`…）——含離格項就不是乾淨的 grid row，半 token 化的 shorthand 比不動更難讀。要 snap 離格值是**設計決策而非還債**（#120 已驗證的結論）。

## 零視覺證明
1. **rem base = 16px**：Electron 整條 CSS 鏈（tailwind.css / tokens.css / hud.css / styles.css / child.css / about.css）**無任何 `html`/`:root`/`body` 的 `font-size` 覆寫**，故 `0.75rem == 12px` 等式成立。
2. **整頁 golden master**：以真實 CSS 鏈載入頁面，比對每個元素 14 個 box/type 屬性的 computed 值，before vs after **byte-identical**：
   - `index.html` — 195 元素 / 2730 個值，`identical: true`、`diffCount: 0`
   - `child.html` — 60 元素，`identical: true`、`diffCount: 0`
3. **Rule-level probe**：14 個 token 在真實鏈中解析值全部 `MATCH`（`--space-1`→4px …`--text-3xl`→30px）。這一步不可省，因為 `tailwind.css` 會吐出**同名**的 `--text-xs/sm/2xl`（memory 坑 1）——實測值相同，且它在 `@layer theme`（分層）而 `tokens.css` 在 `:root`（未分層），**未分層必勝**，兩重保險。

## 驗證
- `node scripts/check-css-tokens.mjs` ✓（通過後 `--update` 下修 baseline）
- Electron jest：**525 passed / 32 suites**
- `npx webpack`：三 bundle 全部 compiled successfully
- 無測試讀取 `danmu-desktop/styles.css` / `child.css`（已 grep 確認），故無 #150 那種 contract-test 斷言風險
- 未在被 tailwind 掃描的 CSS 引入新 `var(--text-*)`（此二檔不在 server scanner 範圍）→ 無需重生 `tailwind.css`

Refs #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)