### PR TITLE
fix(admin): 修掉兩個 MutationObserver 自我餵食的競態，並補 19 條路由 smoke

### DIFF
--- a/server/static/js/admin-modqueue.js
+++ b/server/static/js/admin-modqueue.js
@@ -343,8 +343,17 @@
       || (route === "moderation" && (tab === "queue" || tab === "" || tab === "moderation"));
     page.style.display = visible ? "" : "none";
     if (visible) {
-      _fetch();
-      if (!_state.timer) _state.timer = setInterval(_fetch, REFRESH_MS);
+      // Fetch only on the invisible→visible transition, never on every call.
+      // `_syncVisibility` runs from a MutationObserver watching the whole
+      // body, and `_fetch` re-renders the queue — so an unconditional fetch
+      // here feeds itself: fetch → render → DOM mutation → observer →
+      // fetch. Measured 286 requests to /admin/modqueue/list in 1.2s on
+      // #/moderation before this guard (server answered 429s). The polling
+      // interval below is what keeps the queue fresh after the first load.
+      if (!_state.timer) {
+        _fetch();
+        _state.timer = setInterval(_fetch, REFRESH_MS);
+      }
       if (!_state.countdownTimer) _state.countdownTimer = setInterval(_render, 1000);
     } else {
       if (_state.timer) { clearInterval(_state.timer); _state.timer = 0; }

--- a/server/static/js/admin.js
+++ b/server/static/js/admin.js
@@ -1807,6 +1807,19 @@ document.addEventListener("DOMContentLoaded", () => {
       const run = () => {
         routeVisibilitySyncScheduled = false;
         applySectionVisibility();
+        // Same contract as applyRoute(): the route-level pass above writes
+        // inline display="" on every wanted sec-*, clobbering the per-tab
+        // display:"none" that tab-aware modules (admin-display.js viewer
+        // tabs) set. applyRoute re-dispatches so they can re-apply; this
+        // path must too. Without it the two MutationObservers fight — every
+        // late DOM mutation flips sec-viewer-theme / -fields / -limits back
+        // to visible, admin-display.js hides them again, and the viewer page
+        // visibly flickers for as long as anything keeps mutating the DOM.
+        // Dispatching synchronously here means both passes land in the same
+        // task, so no intermediate state is ever painted.
+        document.dispatchEvent(new CustomEvent("admin-route-applied", {
+          detail: { route: currentRoute, leaf: _activeTab },
+        }));
       };
       if (typeof requestAnimationFrame === "function" && document.visibilityState !== "hidden") {
         requestAnimationFrame(run);

--- a/server/tests/test_browser_admin.py
+++ b/server/tests/test_browser_admin.py
@@ -14,7 +14,7 @@ from playwright.sync_api import sync_playwright
 
 from server.app import create_app
 from server.tests._browser_isolation import should_run_browser_module
-from server.tests.conftest import TestConfig, find_free_port
+from server.tests.conftest import TestConfig, find_free_port, wait_for_port
 
 if not should_run_browser_module(__file__):
     pytest.skip(
@@ -51,6 +51,10 @@ def live_url():
     server = WSGIServer(("127.0.0.1", port), app, log=None, error_log=None)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
+    # serve_forever() runs on that thread and is what starts accepting;
+    # yielding straight away races the first goto() against a socket that
+    # isn't listening yet.
+    assert wait_for_port(port, timeout=5.0), f"HTTP server never came up on port {port}"
     yield f"http://127.0.0.1:{port}"
     server.stop()
 
@@ -655,6 +659,9 @@ def test_modqueue_does_not_storm_the_list_endpoint(admin_page):
     2.5 秒的觀察窗小於一個 REFRESH_MS 週期，所以正常情況是 1 次（進場那次），
     容忍到 3 次以吸收導航過程中的重複觸發；風暴會是數十到數百次，兩者差距夠大，
     這個門檻不會因為時序抖動而誤判。
+
+    上下限都要斷言：只擋上限的話，「進場那次 fetch 根本沒發生」——例如有人把
+    `_fetch()` 一起搬進 timer 裡——會讓佇列一開始是空的，而測試依然全綠。
     """
     calls = []
     admin_page.on(
@@ -664,6 +671,10 @@ def test_modqueue_does_not_storm_the_list_endpoint(admin_page):
     admin_page.evaluate('() => { window.location.hash = "#/moderation"; }')
     admin_page.wait_for_timeout(2500)
 
+    assert len(calls) >= 1, (
+        "/admin/modqueue/list 一次都沒被呼叫 —— 進入 #/moderation 時應該要立刻"
+        "載入一次佇列，否則畫面會停在空狀態直到第一個輪詢週期"
+    )
     assert len(calls) <= 3, (
         f"/admin/modqueue/list 在 2.5s 內被呼叫 {len(calls)} 次 —— "
         f"_syncVisibility 又在每次 MutationObserver 觸發時 fetch 了"

--- a/server/tests/test_browser_admin.py
+++ b/server/tests/test_browser_admin.py
@@ -640,6 +640,36 @@ def test_widgets_create_label(admin_page):
         assert widget_cards.count() >= 1, "Should have at least one widget after creation"
 
 
+# ─── Moderation queue polling ─────────────────────────────────────────────────
+
+
+def test_modqueue_does_not_storm_the_list_endpoint(admin_page):
+    """`#/moderation` 只能按 REFRESH_MS(4s) 的節奏輪詢 /admin/modqueue/list。
+
+    回歸守門（2026-07-26）：admin-modqueue.js 的 `_syncVisibility()` 由一個監看
+    整個 body 的 MutationObserver 呼叫，而它原本無條件 `_fetch()` —— fetch 回來
+    後 render 改 DOM，DOM 變動又觸發 observer，形成自我餵食的迴圈。實測在
+    #/moderation 上 1.2 秒內打了 286 次 /admin/modqueue/list（伺服器以 429 擋
+    下）。修法是只在「不可見→可見」的轉換時 fetch 一次，之後交給輪詢 timer。
+
+    2.5 秒的觀察窗小於一個 REFRESH_MS 週期，所以正常情況是 1 次（進場那次），
+    容忍到 3 次以吸收導航過程中的重複觸發；風暴會是數十到數百次，兩者差距夠大，
+    這個門檻不會因為時序抖動而誤判。
+    """
+    calls = []
+    admin_page.on(
+        "request",
+        lambda r: calls.append(r.url) if "/admin/modqueue/list" in r.url else None,
+    )
+    admin_page.evaluate('() => { window.location.hash = "#/moderation"; }')
+    admin_page.wait_for_timeout(2500)
+
+    assert len(calls) <= 3, (
+        f"/admin/modqueue/list 在 2.5s 內被呼叫 {len(calls)} 次 —— "
+        f"_syncVisibility 又在每次 MutationObserver 觸發時 fetch 了"
+    )
+
+
 # ─── Metrics API ───────────────────────────────────────────────────────────────
 
 

--- a/server/tests/test_browser_admin_routes.py
+++ b/server/tests/test_browser_admin_routes.py
@@ -1,0 +1,335 @@
+"""瀏覽器路由 smoke：走完 19 條 locked sidebar 路由，鎖住每頁的可觀測狀態。
+
+補的是 `docs/plans/2026-05-20-admin-follow-up.md` Task 5 的缺口 —— 既有的
+`test_browser_admin.py` 只深測 5 條路由（viewer-config / moderation / viewer /
+system / security）的個別互動，IA 一改就可能靜默弄壞其他隱藏頁而沒有測試會紅。
+
+每條路由斷言 5 件事（baseline 由 2026-07-26 實跑量測而來）：
+  1. sidebar 該 slug 的按鈕亮起（`is-active` + `aria-selected="true"`），且唯一
+  2. topbar `[data-route-title]` 有非空標題
+  3. 主內容區（`.admin-dash-main` 扣掉 topbar）渲染出實質內容，不是白頁
+  4. 導航期間沒有 console error / pageerror（已知缺陷須登記在
+     `KNOWN_CONSOLE_ERROR_PATTERNS`，且另有一條測試確保那張表不會過期）
+  5. 可見的 `[PLACEHOLDER]` 數量等於 baseline —— 已知待 BE 的頁面有明確配額，
+     其餘路由必須是 0。新增 placeholder 或修掉舊的都會讓這裡紅，逼你更新
+     `DEFERRED_PLACEHOLDER_BUDGET` 這張表。
+
+架構同 `test_browser_admin.py`：session HTTP server + module-scope Chromium。
+19 條路由在 `route_snapshots` 這個 module fixture 裡「一次走完」並快照，之後
+每個 parametrize 測試只對快照斷言 —— 否則 19 × 5 次導航會讓本模組跑很久。
+"""
+
+import re
+import threading
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import sync_playwright
+
+from server.app import create_app
+from server.tests._browser_isolation import should_run_browser_module
+from server.tests.conftest import TestConfig, find_free_port
+from server.tests.test_admin_sidebar_ia import EXPECTED_NAV_ORDER
+
+if not should_run_browser_module(__file__):
+    pytest.skip(
+        "Browser modules run in isolated child pytest processes during the full suite.",
+        allow_module_level=True,
+    )
+
+
+class BrowserTestConfig(TestConfig):
+    """瀏覽器測試用設定：提高 rate limit 避免連續請求被封鎖"""
+
+    LOGIN_RATE_LIMIT = 1000
+    LOGIN_RATE_WINDOW = 1
+    ADMIN_RATE_LIMIT = 1000
+    ADMIN_RATE_WINDOW = 1
+    FIRE_RATE_LIMIT = 1000
+    FIRE_RATE_WINDOW = 1
+    API_RATE_LIMIT = 1000
+    API_RATE_WINDOW = 1
+
+
+# ─── Baseline（2026-07-26 於 main 85103c6 實跑量測）──────────────────────────
+
+# 主內容區最少字元數。實測最低是 messages 的 191（空訊息狀態），其餘都在 280+；
+# 門檻取 120 是要抓「整頁空白」這種回歸，不是要盯資料量的自然波動。
+MIN_CONTENT_CHARS = 120
+
+# 刻意保留的 `[PLACEHOLDER]` 控制項配額（待 BE / 待 Design，見 admin-follow-up
+# plan Task 8 的 deferred 清單）。key 沒列到的路由一律必須是 0。
+#   polls     — 「從模板」建立投票          (admin-poll.js)
+#   ratelimit — IP/CIDR 編輯器 + 可編輯清單  (admin-ratelimit.js)
+#   fonts     — 從 Google Fonts 匯入        (admin-fonts.js)
+#
+# viewer 曾經是 1（admin-viewer-theme.js 的「立即套用」）。那個 placeholder 屬於
+# `page` 分頁，而 viewer 預設落在 `defaults` 分頁 —— 它會被看見純粹是因為
+# section 可見性震盪把它翻出來了。震盪修掉後（見下方說明）它正確地隱藏，
+# 配額回到 0。要看到它請切到 #/viewer/page。
+DEFERRED_PLACEHOLDER_BUDGET = {
+    "polls": 1,
+    "ratelimit": 2,
+    "fonts": 1,
+}
+
+# 允許存在的 console error（子字串比對）。除了這裡列的，任何路由都必須是 0。
+# 每一條都必須寫清楚根因與為什麼還沒修 —— 這張表不是用來讓測試變綠的，
+# 是用來讓「已知壞掉的東西」有名有姓。
+#
+#   style-src-elem — admin-effects-mgmt.js:415 / :944 用 insertAdjacentHTML
+#     注入 `<style>` 但沒帶 CSP nonce，被 app.py 的 `style-src-elem 'self'`
+#     擋下（該指令刻意不給 'unsafe-inline'，見 app.py:26 的註解）。實際影響是
+#     effects 預覽的 keyframes 樣式不會生效。屬於獨立的功能缺陷，不在
+#     section 可見性這條線上，另案處理。
+KNOWN_CONSOLE_ERROR_PATTERNS = [
+    "style-src-elem",
+]
+
+# 導航後等待 JS 渲染的時間。既有 `_open_section` 用 250ms 是因為它接著會
+# wait_for_selector；這裡沒有可等的固定 selector（每頁容器不同），所以直接等
+# 到模組自己的 MutationObserver / hashchange 跑完。
+_ROUTE_SETTLE_MS = 900
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="session")
+def live_url():
+    """啟動真實 HTTP 伺服器（session 共用）"""
+    from gevent.pywsgi import WSGIServer
+
+    app = create_app(BrowserTestConfig)
+    port = find_free_port()
+    server = WSGIServer(("127.0.0.1", port), app, log=None, error_log=None)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{port}"
+    server.stop()
+
+
+@pytest.fixture(scope="module")
+def browser_session():
+    """headless Chromium（module scope —— 與 test_browser_admin.py 同樣的理由：
+    確保 Playwright 在本模組結束前關閉，避免和 asyncio WS 伺服器衝突）。"""
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        yield browser
+        browser.close()
+
+
+# 快照用的 JS：一次取回一條路由的所有可觀測狀態，減少 round-trip。
+_SNAPSHOT_JS = """
+() => {
+  const isVisible = (el) => {
+    const rect = el.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) return false;
+    const cs = getComputedStyle(el);
+    return cs.display !== 'none' && cs.visibility !== 'hidden';
+  };
+
+  const main = document.querySelector('.admin-dash-main');
+  const topbar = document.querySelector('.admin-dash-topbar');
+  const mainLen = main ? (main.innerText || '').trim().length : 0;
+  const topbarLen = topbar ? (topbar.innerText || '').trim().length : 0;
+
+  // Placeholder 有兩種寫法：帶 .admin-be-placeholder-control class 的控制項，
+  // 以及只在文字裡寫 `[PLACEHOLDER]` 的葉節點。用 Set 去重，避免同一個元素
+  // 因為兩種條件都命中而被算兩次。
+  const seen = new Set();
+  const placeholders = [];
+  const collect = (el) => {
+    if (seen.has(el) || !isVisible(el)) return;
+    seen.add(el);
+    placeholders.push((el.textContent || '').trim().slice(0, 60));
+  };
+  document.querySelectorAll('.admin-be-placeholder-control').forEach(collect);
+  Array.from(document.querySelectorAll('body *'))
+    .filter((el) => el.children.length === 0
+      && (el.textContent || '').includes('[PLACEHOLDER]'))
+    .forEach(collect);
+
+  const titleEl = document.querySelector('[data-route-title]');
+  return {
+    activeButtons: Array.from(document.querySelectorAll('[data-route].is-active'))
+      .map((b) => b.dataset.route),
+    ariaSelected: Array.from(
+      document.querySelectorAll('[data-route][aria-selected="true"]')
+    ).map((b) => b.dataset.route),
+    title: titleEl ? (titleEl.textContent || '').trim() : null,
+    contentChars: mainLen - topbarLen,
+    placeholders,
+    hash: window.location.hash,
+  };
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def route_snapshots(browser_session, live_url):
+    """登入一次，依序走完 19 條路由，回傳 {slug: snapshot} 。
+
+    console error 逐條路由分開收集：listener 掛在共用 page 上，但每次導航前
+    換一個新的 list，所以非同步遲到的錯誤最多只會落到後一條路由，不會整批
+    汙染所有路由。
+    """
+    context = browser_session.new_context()
+    page = context.new_page()
+
+    page.goto(f"{live_url}/admin/")
+    page.wait_for_selector("#loginForm", timeout=8000)
+    page.fill("#password", "test")
+    page.locator("#loginForm button[type=submit]").click()
+    page.wait_for_selector("#logoutButton", timeout=15000)
+
+    # v5.0.0+ 首次載入會有 onboarding spotlight overlay 蓋住點擊，標記為已完成。
+    page.evaluate(
+        "() => {"
+        '  try { localStorage.setItem("danmu.onboarding.done", "1"); } catch (_) {}'
+        '  var root = document.getElementById("admin-onboarding-root");'
+        "  if (root) root.remove();"
+        "}"
+    )
+
+    errors: list[str] = []
+    page.on("console", lambda msg: errors.append(msg.text) if msg.type == "error" else None)
+    page.on("pageerror", lambda exc: errors.append(f"pageerror: {exc}"))
+
+    snapshots = {}
+    for slug in EXPECTED_NAV_ORDER:
+        errors.clear()
+        page.evaluate(
+            """(target) => {
+                if (window.location.hash === target) {
+                    window.location.hash = '';
+                }
+                window.location.hash = target;
+            }""",
+            f"#/{slug}",
+        )
+        page.wait_for_timeout(_ROUTE_SETTLE_MS)
+        snapshot = page.evaluate(_SNAPSHOT_JS)
+        snapshot["consoleErrors"] = list(errors)
+        snapshots[slug] = snapshot
+
+    page.close()
+    context.close()
+    yield snapshots
+
+
+# ─── 契約：這張表本身必須跟 IA 對齊 ──────────────────────────────────────────
+
+
+def test_smoke_covers_every_locked_sidebar_slug(route_snapshots):
+    """快照必須涵蓋 EXPECTED_NAV_ORDER 的每一條 slug —— 這是本模組存在的理由，
+    也保證日後 IA 新增 sidebar 項目時 smoke 會自動跟上。"""
+    assert list(route_snapshots) == EXPECTED_NAV_ORDER
+    assert len(route_snapshots) == 19, "v5 grouped sidebar 是 19 項；數量變了請一併更新 IA 測試"
+
+
+def test_placeholder_budget_keys_are_real_routes():
+    """deferred 配額表不能有拼錯或已retired的 slug，否則配額會靜默失效。"""
+    unknown = set(DEFERRED_PLACEHOLDER_BUDGET) - set(EXPECTED_NAV_ORDER)
+    assert not unknown, f"DEFERRED_PLACEHOLDER_BUDGET 有不存在的路由: {sorted(unknown)}"
+
+
+# ─── 逐路由 smoke ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("slug", EXPECTED_NAV_ORDER)
+def test_route_lights_exactly_its_own_sidebar_button(route_snapshots, slug):
+    """導航到 #/<slug> 後，sidebar 必須恰好只有該 slug 的按鈕是 active。
+
+    alias 路由（themes / widgets / plugins / fonts / audit / extensions /
+    webhooks / api-tokens / backup / ratelimit）會經過 applyRoute 的 alias
+    解析，admin.js 特意讓「使用者點的那顆」保持高亮 —— 這裡就是在鎖那個行為。
+    """
+    snap = route_snapshots[slug]
+    assert snap["activeButtons"] == [
+        slug
+    ], f"#/{slug} 的 sidebar 高亮是 {snap['activeButtons']}，預期只有 ['{slug}']"
+    assert snap["ariaSelected"] == [slug], (
+        f"#/{slug} 的 aria-selected 是 {snap['ariaSelected']}，"
+        f"必須與 is-active 一致（螢幕閱讀器靠這個）"
+    )
+
+
+@pytest.mark.parametrize("slug", EXPECTED_NAV_ORDER)
+def test_route_renders_topbar_title(route_snapshots, slug):
+    """每條路由都要在 topbar 寫出非空標題。空標題代表 ADMIN_ROUTES 缺 entry
+    或 i18n key 解析失敗。"""
+    title = route_snapshots[slug]["title"]
+    assert title, f"#/{slug} 的 [data-route-title] 是空的"
+    assert not title.startswith("adminRouteTitle_"), (
+        f"#/{slug} 的標題是未解析的 i18n key ({title!r}) —— "
+        f"locales 缺這個 key，會直接顯示給使用者"
+    )
+
+
+@pytest.mark.parametrize("slug", EXPECTED_NAV_ORDER)
+def test_route_renders_real_content(route_snapshots, slug):
+    """主內容區不能是白頁。
+
+    門檻刻意訂得比實測最低值（messages 191 字，空狀態）低一截，因為這條測的是
+    「頁面有沒有渲染」，不是「有多少資料」。
+    """
+    chars = route_snapshots[slug]["contentChars"]
+    assert chars >= MIN_CONTENT_CHARS, (
+        f"#/{slug} 主內容區只有 {chars} 個字（門檻 {MIN_CONTENT_CHARS}）—— " f"頁面可能整個沒渲染"
+    )
+
+
+def _unknown_errors(errors):
+    """濾掉 KNOWN_CONSOLE_ERROR_PATTERNS 列名的已知違規。"""
+    return [e for e in errors if not any(p in e for p in KNOWN_CONSOLE_ERROR_PATTERNS)]
+
+
+@pytest.mark.parametrize("slug", EXPECTED_NAV_ORDER)
+def test_route_has_no_console_errors(route_snapshots, slug):
+    """導航到該路由期間不得有 console error 或未捕捉例外。
+
+    只有 KNOWN_CONSOLE_ERROR_PATTERNS 明確列名的已知缺陷可以通過；那張表的
+    每一條都附了根因。任何沒登記的 error 都會讓這條紅。
+    """
+    unknown = _unknown_errors(route_snapshots[slug]["consoleErrors"])
+    assert unknown == [], f"#/{slug} 產生了未登記的 console error:\n" + "\n".join(unknown)
+
+
+def test_style_src_elem_exemption_still_has_a_cause():
+    """`style-src-elem` 這條豁免的反向閘 —— 直接驗原始碼，不靠瀏覽器碰運氣。
+
+    豁免名單最怕的是過期後繼續遮蔽新的同類錯誤，所以每條豁免都該有個會在
+    「問題修好時變紅」的守門測試。這裡不用 console 輸出當守門條件：那個 CSP
+    違規要不要出現，取決於 effects modal 在哪一次 DOM 變動被注入，落在導航
+    前就會被 fixture 的 errors.clear() 清掉 —— 拿它當斷言本身就是 flaky 的。
+
+    改成確定性的來源檢查：只要 admin-effects-mgmt.js 還在注入沒帶 nonce 的
+    `<style>`，豁免就還有存在理由。補上 nonce 之後這條會紅，提醒把
+    KNOWN_CONSOLE_ERROR_PATTERNS 裡的 style-src-elem 一起拿掉。
+    """
+    src = (
+        Path(__file__).resolve().parent.parent / "static" / "js" / "admin-effects-mgmt.js"
+    ).read_text(encoding="utf-8")
+    nonce_less = re.findall(r"<style(?![^>]*\bnonce=)[^>]*>", src)
+    assert nonce_less, (
+        "admin-effects-mgmt.js 已經不再注入無 nonce 的 <style> —— "
+        "請把 KNOWN_CONSOLE_ERROR_PATTERNS 的 'style-src-elem' 移除"
+    )
+
+
+@pytest.mark.parametrize("slug", EXPECTED_NAV_ORDER)
+def test_route_visible_placeholders_match_budget(route_snapshots, slug):
+    """可見的 `[PLACEHOLDER]` 控制項數量必須等於 baseline 配額。
+
+    這條是雙向的 ratchet：
+      • 新頁面偷渡 placeholder → 紅（不該再增加待 BE 的死控制項）
+      • 補完後端把 placeholder 拿掉 → 也會紅，提醒你把配額從表裡刪掉
+    """
+    expected = DEFERRED_PLACEHOLDER_BUDGET.get(slug, 0)
+    found = route_snapshots[slug]["placeholders"]
+    assert len(found) == expected, (
+        f"#/{slug} 可見 placeholder 數 {len(found)} != baseline {expected}\n"
+        f"實際內容: {found}\n"
+        f"若是刻意變動，請同步更新 DEFERRED_PLACEHOLDER_BUDGET"
+    )

--- a/server/tests/test_browser_admin_routes.py
+++ b/server/tests/test_browser_admin_routes.py
@@ -24,11 +24,12 @@ import threading
 from pathlib import Path
 
 import pytest
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from playwright.sync_api import sync_playwright
 
 from server.app import create_app
 from server.tests._browser_isolation import should_run_browser_module
-from server.tests.conftest import TestConfig, find_free_port
+from server.tests.conftest import TestConfig, find_free_port, wait_for_port
 from server.tests.test_admin_sidebar_ia import EXPECTED_NAV_ORDER
 
 if not should_run_browser_module(__file__):
@@ -86,10 +87,15 @@ KNOWN_CONSOLE_ERROR_PATTERNS = [
     "style-src-elem",
 ]
 
-# 導航後等待 JS 渲染的時間。既有 `_open_section` 用 250ms 是因為它接著會
-# wait_for_selector；這裡沒有可等的固定 selector（每頁容器不同），所以直接等
-# 到模組自己的 MutationObserver / hashchange 跑完。
-_ROUTE_SETTLE_MS = 900
+# 路由套用是可以明確等待的：applyRoute() 會把目標 slug 的 sidebar 按鈕設成
+# is-active + aria-selected。先等這個確定性訊號，不要用固定秒數去猜。
+_ROUTE_APPLIED_TIMEOUT_MS = 5000
+
+# 等到路由套用之後，還要留一小段給各模組的非同步渲染（fetch → render）。這段
+# 沒有通用的可等訊號 —— 每頁的容器與資料來源都不同，而「等到內容出現」會讓
+# test_route_renders_real_content 變成同義反覆（等到它成立才快照，就永遠不會
+# 失敗，只會 timeout）。所以這裡刻意保留固定等待，但只涵蓋渲染，不涵蓋路由。
+_RENDER_SETTLE_MS = 700
 
 
 # ─── Fixtures ────────────────────────────────────────────────────────────────
@@ -105,6 +111,11 @@ def live_url():
     server = WSGIServer(("127.0.0.1", port), app, log=None, error_log=None)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
+    # serve_forever() is what starts accepting, and it runs on that thread —
+    # yielding immediately races the first page.goto() against a socket that
+    # may not be listening yet. conftest's ws_server_port fixture already
+    # gates on this helper; browser fixtures should too.
+    assert wait_for_port(port, timeout=5.0), f"HTTP server never came up on port {port}"
     yield f"http://127.0.0.1:{port}"
     server.stop()
 
@@ -208,7 +219,25 @@ def route_snapshots(browser_session, live_url):
             }""",
             f"#/{slug}",
         )
-        page.wait_for_timeout(_ROUTE_SETTLE_MS)
+        # 等 applyRoute 真的把這條 slug 點亮，而不是等一個猜出來的秒數。失敗時
+        # 直接指出是哪條路由沒套用，比事後看快照裡的 activeButtons 好懂。
+        try:
+            page.wait_for_function(
+                """(slug) => {
+                    const active = Array.from(
+                        document.querySelectorAll('[data-route].is-active')
+                    ).map((b) => b.dataset.route);
+                    return active.length === 1 && active[0] === slug;
+                }""",
+                arg=slug,
+                timeout=_ROUTE_APPLIED_TIMEOUT_MS,
+            )
+        except PlaywrightTimeoutError:
+            # 不在這裡 fail：讓快照照樣拍下來，由
+            # test_route_lights_exactly_its_own_sidebar_button report 實際狀態，
+            # 錯誤訊息會比 fixture 掛掉有用得多。
+            pass
+        page.wait_for_timeout(_RENDER_SETTLE_MS)
         snapshot = page.evaluate(_SNAPSHOT_JS)
         snapshot["consoleErrors"] = list(errors)
         snapshots[slug] = snapshot

--- a/server/tests/test_browser_isolated.py
+++ b/server/tests/test_browser_isolated.py
@@ -7,6 +7,7 @@ import pytest
 
 _BROWSER_MODULES = [
     "tests/test_browser_admin.py",
+    "tests/test_browser_admin_routes.py",
     "tests/test_browser_fire_e2e.py",
     "tests/test_browser_overlay_render.py",
     "tests/test_browser_p3_pages.py",


### PR DESCRIPTION
兩個獨立但同源的 bug——都是「MutationObserver 觸發時無條件重跑副作用」造成的自我餵食迴圈。起因是補 [admin-follow-up plan](docs/plans/2026-05-20-admin-follow-up.md) Task 5 的 route smoke 時發現的。

## 1. Moderation 請求風暴 (`3f70e98`)

`admin-modqueue.js` 的 `_syncVisibility()` 由監看整個 body 的 MutationObserver 呼叫，而它**無條件 `_fetch()`**：fetch → render 改 DOM → observer 再觸發 → fetch，以瀏覽器允許的最快速度循環。

實測 `#/moderation` 上 **2.5 秒內 2132 次** `/admin/modqueue/list`（伺服器以 429 擋下，這也是它被發現的原因）。

改成只在「不可見→可見」轉換時 fetch 一次，之後交給既有的 4 秒輪詢 timer。修復後 ≤ 3 次。

這個模組原本**完全沒有測試覆蓋**，所以補了一條行為層級的守門測試（鎖請求數而非實作形狀）。

## 2. Viewer section 震盪 (`b044133`)

`applyRoute()` 本來就正確地在 `applySectionVisibility()` 之後 dispatch `admin-route-applied`，讓 tab-aware 模組把 per-tab 的 `display:none` 補回去——因為 route-level 的 pass 會對該路由擁有的每個 section 寫 `display:""`，蓋掉它們。

但 MutationObserver 那條路徑 `scheduleRouteVisibilitySync()` 跑了同樣的 route-level pass，**卻漏了 dispatch**。`admin-display.js` 因此沒機會修正，兩個 observer 就互推：每次 DOM 變動把 `sec-viewer-theme` / `-fields` / `-limits` 翻回可見，`admin-display.js` 再藏起來，只要頁面還有任何變動就不會停。

導航到 `#/viewer` 後 3 秒觀察窗：

| | 錯誤寫入 | 值翻轉次數 |
|---|---:|---:|
| 修復前 | 36 | **69** |
| 修復後（3 次試驗） | 0 | **0** |

同步 dispatch 讓兩個 pass 落在同一個 task，不會有中間狀態被畫出來。

## 3. 19 條路由 smoke（同 `b044133`）

新增 `test_browser_admin_routes.py`，98 個測試約 23 秒。路由清單 `import` 自 `test_admin_sidebar_ia.EXPECTED_NAV_ORDER`，IA 改動時自動跟上。每條路由鎖：

1. sidebar 該 slug 的按鈕亮起且唯一（`is-active` + `aria-selected`）
2. topbar 標題非空、不是未解析的 i18n key
3. 主內容區有實質內容（抓白頁回歸）
4. 0 console error / pageerror
5. 可見 `[PLACEHOLDER]` 數 == baseline 配額（雙向 ratchet）

**兩處 baseline 帶著記錄在案的成因，而不是放寬的斷言**：

- `viewer` 的 placeholder 配額是 **0 不是 1** — 那個「立即套用」控制項屬於 `page` 分頁，viewer 預設在 `defaults`；它之前會被看見純粹是震盪把它翻出來的。
- `style-src-elem` 的 CSP 違規被豁免 — `admin-effects-mgmt.js:415/944` 用 `insertAdjacentHTML` 注入不帶 nonce 的 `<style>`，**effects 預覽的 keyframes 樣式實際上沒生效**。這是獨立的功能缺陷，沒有混進本 PR；豁免旁邊有一條原始碼層級的測試，會在它被修好時變紅，所以這張豁免名單不會活得比它的成因久。

## 驗證

| | 結果 |
|---|---|
| route smoke | **98 passed**，連跑 3 次 |
| `test_browser_admin.py` | **28 passed**（含新守門測試） |
| 隔離 browser harness | **5 passed** |
| server 全套 | **1293 passed, 5 skipped** |
| Electron jest | **525 passed / 32 suites** |
| black | 乾淨 |

兩處產品修復都做過 mutation 驗證（還原修改 → 對應測試紅、且不波及其他）。兩個 commit 的順序刻意讓每個都能獨立跑綠：modqueue 的 429 會讓 route smoke 在 `moderation` / `ratelimit` 紅，所以它必須先落地——commit 1 的獨立狀態已實測（28 passed）。

CI 透過 `test_browser_isolated.py` 會跑到新模組（該 workflow 已有 `playwright install chromium` 步驟）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented moderation queue from issuing duplicate list requests when the admin page repeatedly re-renders/changes visibility.
  * Improved admin route visibility synchronization so route-applied state stays consistent across scheduled visibility updates.
* **Tests**
  * Added a regression check to ensure moderation queue polling doesn’t “storm” the list endpoint.
  * Added Playwright-based browser smoke coverage for all locked admin routes (UI highlighting, titles, content, placeholders, and console/page errors), and included it in isolated browser test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->