### PR TITLE
fix(csp): 讓 style-src-elem 接受 nonce，修好被靜默丟棄的注入樣式

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -25,7 +25,12 @@ from .ws import init_ws, start_ws_broadcast
 def _build_content_security_policy(nonce: str) -> str:
     # `style-src-elem` forbids `'unsafe-inline'` so a successful HTML injection
     # cannot smuggle in an attacker-controlled `<style>` block (the main
-    # CSS-exfiltration vector via `@import` or attribute selectors).
+    # CSS-exfiltration vector via `@import` or attribute selectors). It does
+    # allow `'nonce-…'`, which is what lets our own modules inject a `<style>`
+    # (see AdminUtils.styleTag): the nonce is per-response and unguessable, so
+    # injected markup still cannot bring styles with it. Without the nonce
+    # source here there is no legitimate way for JS to add a stylesheet at all
+    # — which is exactly how the effects preview silently lost its keyframes.
     # `style-src-attr` stays permissive so template `style=""` attributes and
     # JS-driven `.style.foo = …` assignments continue to work. `style-src`
     # is kept as a fallback for user agents that don't support the split.
@@ -38,7 +43,7 @@ def _build_content_security_policy(nonce: str) -> str:
         "img-src 'self' https: data:",
         "font-src 'self' https://fonts.gstatic.com data:",
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-        "style-src-elem 'self' https://fonts.googleapis.com",
+        f"style-src-elem 'self' 'nonce-{nonce}' https://fonts.googleapis.com",
         "style-src-attr 'unsafe-inline'",
         "connect-src 'self' ws: wss:",
         f"script-src 'self' 'nonce-{nonce}'",

--- a/server/static/js/admin-effects-mgmt.js
+++ b/server/static/js/admin-effects-mgmt.js
@@ -13,6 +13,14 @@
   function showToast(msg, ok) { return window.showToast(msg, ok); }
   var ServerI18n = window.ServerI18n;
 
+  // Both style tags this module injects must carry the CSP nonce, or
+  // `style-src-elem` drops them. Resolved per call because the nonce lives in
+  // the served document, not in this file. admin-utils.js is loaded first
+  // (admin.html:85), same as for every other module that uses AdminUtils.
+  function styleTag(id, css) {
+    return window.AdminUtils.styleTag(id, css);
+  }
+
   let _effectModalRestoreFocusEl = null;
 
   function getEffectModalFocusableElements() {
@@ -412,7 +420,7 @@
                 <div id="effectPreviewBox" style="background:var(--color-bg-elevated);padding:20px;border-radius:8px;display:flex;align-items:center;justify-content:center;min-height:80px;">
                   <span id="effectPreviewText" style="font-size:32px;color:var(--color-text-strong);display:inline-block;">${ServerI18n.t("previewText")}</span>
                 </div>
-                <style id="effectPreviewStyle"></style>
+                ${styleTag("effectPreviewStyle", "")}
                 <div id="effectPreviewParams" class="flex flex-col gap-2"></div>
                 <p id="effectPreviewError" class="text-xs m-0 hidden" style="color:var(--hud-crimson)"></p>
               </div>
@@ -941,7 +949,7 @@
     // Inline animation CSS for preview cells
     const animId  = "fx-anim-" + eff.name.replace(/[^a-z0-9]/gi, "-");
     const previewCSS = (keyframes && animation)
-      ? `<style id="${escapeHtml(animId)}">${keyframes}</style>`
+      ? styleTag(animId, keyframes)
       : "";
     const animAttr = animation ? `animation:${animation};animation-play-state:running;` : "";
 

--- a/server/static/js/admin-onboarding.js
+++ b/server/static/js/admin-onboarding.js
@@ -19,6 +19,14 @@
   const DONE_KEY  = "danmu.onboarding.done";
   const ROOT_ID   = "admin-onboarding-root";
 
+  // The tour's spotlight ring animates via @keyframes, which has to live in a
+  // real style element — and `style-src-elem` only accepts the per-response
+  // nonce, so injecting one without it means the whole block is dropped and
+  // the ring just sits there. AdminUtils.styleTag() attaches the nonce.
+  function styleTag(css) {
+    return window.AdminUtils.styleTag("", css);
+  }
+
   const STEPS = [
     {
       n: 1,
@@ -292,7 +300,7 @@
         </div>
       </div>
 
-      <style>
+      ${styleTag(`
         @keyframes ob-pulse {
           0%,100% { box-shadow:0 0 0 2px rgba(56,189,248,.25),0 0 20px rgba(56,189,248,.45); }
           50%      { box-shadow:0 0 0 4px rgba(56,189,248,.4),0 0 32px rgba(56,189,248,.7); }
@@ -318,7 +326,7 @@
           background:rgba(56,189,248,.25);flex:1;
         }
         .ob-prog-dot--done { background:var(--color-primary,#38bdf8); }
-      </style>`;
+      `)}`;
   }
 
   function _findRect(selector) {

--- a/server/static/js/admin-utils.js
+++ b/server/static/js/admin-utils.js
@@ -30,6 +30,42 @@
     return div.innerHTML;
   }
 
+  // ── CSP nonce ─────────────────────────────────────────────────────────────
+  //
+  // app.py's CSP sets `style-src-elem 'self'` with no 'unsafe-inline' on
+  // purpose (see the comment above _build_content_security_policy): a
+  // successful HTML injection must not be able to bring its own styles.
+  // The flip side is that any <style> element JS injects has to carry the
+  // per-request nonce, or the browser drops it — silently, apart from a
+  // console warning. `style-src-attr` stays permissive, so `el.style.foo = …`
+  // is unaffected; this is only about <style> elements.
+  //
+  // Read the `.nonce` property rather than the attribute: browsers blank out
+  // the nonce content attribute after parsing, so getAttribute("nonce")
+  // returns "" while the property still holds the real value.
+  function cspNonce() {
+    var carrier = document.querySelector("script[nonce]");
+    return (carrier && carrier.nonce) || "";
+  }
+
+  // Build a <style> tag string that survives the CSP. Prefer this over hand-
+  // writing `<style>` into an HTML string — forgetting the nonce fails quietly
+  // at runtime, and `test_no_nonce_less_style_injection` pins that.
+  //
+  // `css` is inserted verbatim: it is stylesheet text, so HTML-escaping it
+  // would corrupt selectors. Callers own their CSS source.
+  function styleTag(id, css) {
+    var nonce = cspNonce();
+    return (
+      "<style" +
+      (id ? ' id="' + escapeHtml(id) + '"' : "") +
+      (nonce ? ' nonce="' + escapeHtml(nonce) + '"' : "") +
+      ">" +
+      (css || "") +
+      "</style>"
+    );
+  }
+
   // Shared close/dismiss/remove glyph. Replaces the ad-hoc ✕ / × text nodes
   // (mixed U+2715 and U+00D7) scattered across admin modules with one crisp,
   // theme-aware SVG: strokes currentColor so it inherits each button's color
@@ -46,6 +82,8 @@
     loadDetailsState: loadDetailsState,
     saveDetailsState: saveDetailsState,
     escapeHtml: escapeHtml,
+    cspNonce: cspNonce,
+    styleTag: styleTag,
     closeIcon: CLOSE_ICON,
   };
 })();

--- a/server/tests/test_api_routes.py
+++ b/server/tests/test_api_routes.py
@@ -120,6 +120,33 @@ def test_index_uses_csp_nonce_and_no_inline_event_handlers(client):
     assert "onchange=" not in body
 
 
+def test_csp_style_src_elem_accepts_the_response_nonce(client):
+    """`style-src-elem` 必須同時做到兩件事：擋掉 'unsafe-inline'，以及接受
+    當次回應的 nonce。
+
+    只做前者的話，JS 就完全沒有合法途徑加上 stylesheet —— effects 預覽的
+    keyframes 曾經就是這樣被靜靜丟掉的（`AdminUtils.styleTag()` 產生的
+    `<style nonce=…>` 也一樣被擋，因為政策裡根本沒有 nonce 來源）。兩個條件
+    要一起成立才有意義，所以綁在同一條測試。
+    """
+    res = client.get("/admin/")
+    csp = res.headers["Content-Security-Policy"]
+
+    nonce_match = re.search(r"script-src 'self' 'nonce-([^']+)'", csp)
+    assert nonce_match is not None
+    nonce = nonce_match.group(1)
+
+    directive = next(d.strip() for d in csp.split(";") if d.strip().startswith("style-src-elem"))
+    assert f"'nonce-{nonce}'" in directive, (
+        f"style-src-elem 必須接受當次回應的 nonce，否則 JS 無法合法注入 "
+        f"<style>；目前是 {directive!r}"
+    )
+    assert "'unsafe-inline'" not in directive, (
+        f"style-src-elem 不得放行 'unsafe-inline' —— 那會讓注入的 HTML "
+        f"也能帶樣式進來；目前是 {directive!r}"
+    )
+
+
 def test_admin_and_overlay_use_response_csp_nonce(client):
     admin_res = client.get("/admin/")
     admin_csp = admin_res.headers["Content-Security-Policy"]

--- a/server/tests/test_browser_admin_routes.py
+++ b/server/tests/test_browser_admin_routes.py
@@ -8,8 +8,7 @@ system / security）的個別互動，IA 一改就可能靜默弄壞其他隱藏
   1. sidebar 該 slug 的按鈕亮起（`is-active` + `aria-selected="true"`），且唯一
   2. topbar `[data-route-title]` 有非空標題
   3. 主內容區（`.admin-dash-main` 扣掉 topbar）渲染出實質內容，不是白頁
-  4. 導航期間沒有 console error / pageerror（已知缺陷須登記在
-     `KNOWN_CONSOLE_ERROR_PATTERNS`，且另有一條測試確保那張表不會過期）
+  4. 導航期間沒有 console error / pageerror（零豁免）
   5. 可見的 `[PLACEHOLDER]` 數量等於 baseline —— 已知待 BE 的頁面有明確配額，
      其餘路由必須是 0。新增 placeholder 或修掉舊的都會讓這裡紅，逼你更新
      `DEFERRED_PLACEHOLDER_BUDGET` 這張表。
@@ -73,19 +72,6 @@ DEFERRED_PLACEHOLDER_BUDGET = {
     "ratelimit": 2,
     "fonts": 1,
 }
-
-# 允許存在的 console error（子字串比對）。除了這裡列的，任何路由都必須是 0。
-# 每一條都必須寫清楚根因與為什麼還沒修 —— 這張表不是用來讓測試變綠的，
-# 是用來讓「已知壞掉的東西」有名有姓。
-#
-#   style-src-elem — admin-effects-mgmt.js:415 / :944 用 insertAdjacentHTML
-#     注入 `<style>` 但沒帶 CSP nonce，被 app.py 的 `style-src-elem 'self'`
-#     擋下（該指令刻意不給 'unsafe-inline'，見 app.py:26 的註解）。實際影響是
-#     effects 預覽的 keyframes 樣式不會生效。屬於獨立的功能缺陷，不在
-#     section 可見性這條線上，另案處理。
-KNOWN_CONSOLE_ERROR_PATTERNS = [
-    "style-src-elem",
-]
 
 # 路由套用是可以明確等待的：applyRoute() 會把目標 slug 的 sidebar 按鈕設成
 # is-active + aria-selected。先等這個確定性訊號，不要用固定秒數去猜。
@@ -309,41 +295,52 @@ def test_route_renders_real_content(route_snapshots, slug):
     )
 
 
-def _unknown_errors(errors):
-    """濾掉 KNOWN_CONSOLE_ERROR_PATTERNS 列名的已知違規。"""
-    return [e for e in errors if not any(p in e for p in KNOWN_CONSOLE_ERROR_PATTERNS)]
-
-
 @pytest.mark.parametrize("slug", EXPECTED_NAV_ORDER)
 def test_route_has_no_console_errors(route_snapshots, slug):
     """導航到該路由期間不得有 console error 或未捕捉例外。
 
-    只有 KNOWN_CONSOLE_ERROR_PATTERNS 明確列名的已知缺陷可以通過；那張表的
-    每一條都附了根因。任何沒登記的 error 都會讓這條紅。
+    這裡沒有豁免名單。曾經有一條給 `style-src-elem` 的（effects 預覽注入
+    `<style>` 卻沒有可用的 nonce 來源），連同根因一起修掉了 —— 見
+    `test_admin_js_never_injects_a_nonce_less_style` 與 app.py 的 CSP 建構。
     """
-    unknown = _unknown_errors(route_snapshots[slug]["consoleErrors"])
-    assert unknown == [], f"#/{slug} 產生了未登記的 console error:\n" + "\n".join(unknown)
+    errors = route_snapshots[slug]["consoleErrors"]
+    assert errors == [], f"#/{slug} 產生了 console error:\n" + "\n".join(errors)
 
 
-def test_style_src_elem_exemption_still_has_a_cause():
-    """`style-src-elem` 這條豁免的反向閘 —— 直接驗原始碼，不靠瀏覽器碰運氣。
+def _strip_js_comments(src: str) -> str:
+    """粗略剝掉 JS 註解，免得註解裡提到 `<style>` 也被當成違規。
 
-    豁免名單最怕的是過期後繼續遮蔽新的同類錯誤，所以每條豁免都該有個會在
-    「問題修好時變紅」的守門測試。這裡不用 console 輸出當守門條件：那個 CSP
-    違規要不要出現，取決於 effects modal 在哪一次 DOM 變動被注入，落在導航
-    前就會被 fixture 的 errors.clear() 清掉 —— 拿它當斷言本身就是 flaky 的。
-
-    改成確定性的來源檢查：只要 admin-effects-mgmt.js 還在注入沒帶 nonce 的
-    `<style>`，豁免就還有存在理由。補上 nonce 之後這條會紅，提醒把
-    KNOWN_CONSOLE_ERROR_PATTERNS 裡的 style-src-elem 一起拿掉。
+    不需要真正的 parser：這裡只在乎 `<style…>` 這個字面樣式，而它出現在
+    字串字面量裡的機率遠高於出現在被誤刪的行內。
     """
-    src = (
-        Path(__file__).resolve().parent.parent / "static" / "js" / "admin-effects-mgmt.js"
-    ).read_text(encoding="utf-8")
-    nonce_less = re.findall(r"<style(?![^>]*\bnonce=)[^>]*>", src)
-    assert nonce_less, (
-        "admin-effects-mgmt.js 已經不再注入無 nonce 的 <style> —— "
-        "請把 KNOWN_CONSOLE_ERROR_PATTERNS 的 'style-src-elem' 移除"
+    src = re.sub(r"/\*.*?\*/", "", src, flags=re.S)
+    return re.sub(r"^\s*//.*$", "", src, flags=re.M)
+
+
+def test_admin_js_never_injects_a_nonce_less_style():
+    """任何 admin 模組都不得把不帶 nonce 的 `<style>` 寫進 HTML 字串。
+
+    `style-src-elem` 只接受 'self' 與當次請求的 nonce，所以少了 nonce 的
+    `<style>` 會被瀏覽器靜靜丟掉 —— 只有一行 console 警告，樣式無聲失效。
+    effects 預覽就是這樣壞掉的：keyframes 寫進去了，但那個 <style> 從頭到尾
+    沒有 sheet，畫面上跑的是別處同名的舊動畫。
+
+    用 `AdminUtils.styleTag()` 產生就會自動帶上 nonce。這條測試掃全部
+    admin-*.js，讓下一個手寫 `<style>` 的人在 CI 就被擋下來，而不是等到某天
+    有人發現預覽沒反應。
+    """
+    js_dir = Path(__file__).resolve().parent.parent / "static" / "js"
+    offenders = {}
+    for path in sorted(js_dir.glob("admin*.js")):
+        src = _strip_js_comments(path.read_text(encoding="utf-8"))
+        # 找字面上寫死的完整開標籤。styleTag() 是用字串拼接組出來的
+        # （`"<style" + …`），沒有字面上的 `>`，所以不會被自己抓到。
+        hits = re.findall(r"<style(?![^>]*\bnonce=)[^>]*>", src)
+        if hits:
+            offenders[path.name] = hits
+    assert not offenders, (
+        "以下模組把不帶 nonce 的 <style> 寫進 HTML 字串，會被 CSP 丟掉；"
+        f"請改用 AdminUtils.styleTag()：\n{offenders}"
     )
 
 


### PR DESCRIPTION
> 疊在 #157 之上（base 是 `claude/fix-admin-visibility-races`）。#157 merge 後這個 PR 的 base 會自動變成 main。

## 診斷修正

原本的追蹤單（以及 #157 裡那條豁免的註解）把根因寫成「注入 `<style>` 時忘了帶 CSP nonce」。**那是錯的。**

實際情況是：`_build_content_security_policy` 的註解宣稱 JS 注入的 `<style>` 必須帶 nonce，但 `style-src-elem` 從來就沒有把 `'nonce-…'` 列為來源，只有 `'self'`——`script-src` 有，它沒有。所以 JS **根本沒有任何合法途徑**加上 stylesheet，帶不帶 nonce 都一樣被丟掉，只留一行 console 警告。

先補 nonce 到注入端、policy 不動時實測仍然是 4 筆違規，才發現這件事。

## 兩個被靜默弄壞的功能

都靠 `@keyframes`，而 `@keyframes` 沒辦法透過 `style-src-attr` 放行的 `.style.foo = …` 表達，只能放在真正的 `<style>` 裡：

| | 修復前 | 修復後 |
|---|---|---|
| **effects 預覽**（`admin-effects-mgmt.js`） | `<style>` 完全沒有 `sheet`，4 筆違規 | sheet 裡有 `@keyframes dme-blink`，0 違規 |
| **onboarding 導覽**（`admin-onboarding.js`） | `ob-pulse` 從未註冊，spotlight 光圈不會脈動 | `ob-pulse` 已註冊，0 違規 |

effects 預覽特別隱蔽：它**看起來**像正常的，因為 demo 格會退回到同名的內建動畫。實際後果是——編輯 `.dme` 內容再按重新整理，看到的是**舊的**動畫；而全新的效果則完全不會動。

## 修法

1. `style-src-elem` 加上 `'nonce-{nonce}'`。`'unsafe-inline'` 維持關閉，所以注入的 HTML 仍然帶不進樣式——nonce 是每次回應隨機且不可猜。
2. `AdminUtils.styleTag(id, css)`：唯一負責掛上 nonce 的地方。
3. 兩個模組改用它。

## 防回歸

- `test_admin_js_never_injects_a_nonce_less_style` — 掃過所有 `admin*.js`，找手寫的無 nonce `<style>`。**onboarding 那個 case 就是這條掃出來的**，我原本只知道 effects 一處。
- `test_csp_style_src_elem_accepts_the_response_nonce` — 同時釘住「接受本次 nonce」與「不得放行 `'unsafe-inline'`」。兩個條件要一起成立才有意義，所以綁在同一條。這條在全套會跑（不像 browser 模組會 skip）。Mutation 驗證過：policy 改回原樣就紅。
- #157 裡的 `KNOWN_CONSOLE_ERROR_PATTERNS` 整張表移除——route smoke 現在要求零 console error，沒有任何豁免。這同時回應了 CodeRabbit 對該表「比對太寬鬆」的意見。

## 驗證

| | 結果 |
|---|---|
| server 全套 | **1294 passed, 5 skipped** |
| 隔離 browser harness | **5 passed** |
| `test_browser_admin_routes.py` + `test_browser_admin.py` | **126 passed** |
| Electron jest | **525 passed / 32 suites** |
| black | 乾淨 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin page compatibility with Content Security Policy rules by securely applying nonces to dynamically generated styles.
  * Fixed live previews, animations, and onboarding effects that could be blocked by browser security policies.
  * Admin routes now load without console errors.

* **Tests**
  * Added coverage to verify nonce-protected styles and prevent unsafe inline style injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->