### PR TITLE
ci: 讓 test.yml 可以手動觸發

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,19 @@
 name: Tests
 
 on:
+  # Manual trigger — pick any branch from the Actions tab (or `gh workflow run
+  # test.yml --ref <branch>`). Needed because the PR trigger below only fires
+  # for PRs whose base is `main`: a stacked PR (base = another feature branch)
+  # runs none of these jobs, and `gh pr checks` shows only the few checks that
+  # did run, which is indistinguishable from everything passing. Retargeting
+  # such a PR to `main` afterwards does not help either — that is an `edited`
+  # event, and the default pull_request activity types are opened /
+  # synchronize / reopened. Without this, the only ways to get a run were to
+  # close-and-reopen the PR or to push a throwaway commit.
+  #
+  # Note: `paths` filters do not apply to manual runs, so this always runs the
+  # full suite regardless of what changed.
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
`pull_request` 觸發器只對 base 是 `main` 的 PR 生效。stacked PR（base 指向另一個 feature 分支）不會跑任何 job，而 `gh pr checks` 只會列出有跑到的那兩三個（CodeRabbit、GitGuardian）——**看起來跟全部通過一模一樣**。

這在 #158 上實際發生過：它疊在 #157 上時只有 2 個 check，全 pass，但 `test` / `build` / `js-test` / `e2e` 一個都沒跑。

把 base 改成 `main` 也救不回來——那是 `edited` 事件，而 `pull_request` 預設的 activity types 是 `opened` / `synchronize` / `reopened`。偏偏 CodeRabbit 會在 `edited` 時醒過來開始 review，更容易讓人以為 CI 也跟著跑了（#158 當時就是這樣：CodeRabbit 顯示 "Review completed"，Tests 依然缺席）。

在此之前，要讓這種分支跑 CI 只有兩條路：close 再 reopen PR，或推一個沒意義的 commit。加上 `workflow_dispatch` 就有了直接的做法：

```bash
gh workflow run test.yml --ref <branch>
```

也可以從 Actions 分頁選分支手動跑。

## 兩個細節

- `paths` 過濾器不適用於手動觸發，所以 dispatch 一定會跑完整套，不管改了什麼。
- **要 merge 進 `main` 之後才生效** —— GitHub 只對預設分支上存在的 workflow 檔提供 workflow_dispatch 選項。

## 驗證

YAML 解析通過，觸發器為 `['workflow_dispatch', 'push', 'pull_request']`，5 個 job（`test` / `js-test` / `e2e` / `pip-audit` / `pre-commit`）都完整保留。因為 `.github/workflows/**` 在 `paths` 清單裡，這個 PR 自己就會跑完整套 CI，等於順便驗證了改動沒有弄壞 workflow。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the ability to manually run the test workflow on demand.
  * Manual runs are available independently of automatic branch and path-based triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->