### PR TITLE
refactor(admin): 把所有原生 confirm() 換成 HUD modal

### DIFF
--- a/danmu-desktop/tests/admin-no-native-confirm.test.js
+++ b/danmu-desktop/tests/admin-no-native-confirm.test.js
@@ -1,0 +1,71 @@
+const { test, expect } = require("@jest/globals");
+const fs = require("fs");
+const path = require("path");
+
+// Admin destructive actions must go through the HUD confirm modal
+// (`window.HudConfirm.open()` in server/static/js/admin-hud-modal.js), not the
+// browser's native `confirm()`.
+//
+// Native confirm() is a hard blocker on the whole tab, ignores the admin's
+// visual language entirely, and on top of that it cannot render the
+// title / subtitle / severity structure the HUD modal was built for. The modal
+// helper's own docstring says it exists to "replace the ad-hoc confirm() calls
+// scattered through the admin modules" — this test is what keeps them from
+// coming back.
+//
+// Follow-up plan reference: docs/plans/2026-05-20-admin-follow-up.md Task 4.
+
+const STATIC_JS = path.join(__dirname, "..", "..", "server", "static", "js");
+
+// `window.confirm(...)` and bare `confirm(...)`. The negative lookbehind keeps
+// property access like `HudConfirm.open` / `opts.confirm` from matching, and
+// `\w` guards against names that merely end in "confirm".
+const NATIVE_CONFIRM_PATTERNS = [/\bwindow\.confirm\s*\(/, /(?<![.\w])confirm\s*\(/];
+
+/**
+ * Strip comments and string literals so a `confirm(` mentioned in prose or
+ * inside a message never counts as a call site.
+ */
+function stripCommentsAndStrings(src) {
+  return (
+    src
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/^\s*\/\/.*$/gm, "")
+      // Template literals can span lines and embed expressions; dropping them
+      // wholesale is fine because a confirm() call is never written inside one.
+      .replace(/`(?:[^`\\]|\\[\s\S])*`/g, '""')
+      .replace(/'(?:[^'\\\n]|\\.)*'/g, '""')
+      .replace(/"(?:[^"\\\n]|\\.)*"/g, '""')
+  );
+}
+
+function nativeConfirmCallSites(src) {
+  const cleaned = stripCommentsAndStrings(src);
+  return cleaned
+    .split("\n")
+    .map((line, i) => ({ line: i + 1, text: line.trim() }))
+    .filter(({ text }) => NATIVE_CONFIRM_PATTERNS.some((re) => re.test(text)));
+}
+
+test("no admin module calls native confirm()", () => {
+  const offenders = {};
+  for (const file of fs.readdirSync(STATIC_JS).filter((f) => /^admin.*\.js$/.test(f))) {
+    const src = fs.readFileSync(path.join(STATIC_JS, file), "utf8");
+    const hits = nativeConfirmCallSites(src);
+    if (hits.length) offenders[file] = hits;
+  }
+
+  expect(offenders).toEqual({});
+});
+
+test("the confirm detector actually detects", () => {
+  // Guards the regex/stripping above: a rewrite that accidentally neuters the
+  // detector would otherwise make the test above pass vacuously.
+  expect(nativeConfirmCallSites('if (!confirm("x")) return;')).toHaveLength(1);
+  expect(nativeConfirmCallSites("const ok = window.confirm(msg);")).toHaveLength(1);
+  // ...and does not fire on the things it must ignore.
+  expect(nativeConfirmCallSites("await window.HudConfirm.open({});")).toHaveLength(0);
+  expect(nativeConfirmCallSites("// if (!confirm('x')) return;")).toHaveLength(0);
+  expect(nativeConfirmCallSites('const s = "confirm(";')).toHaveLength(0);
+  expect(nativeConfirmCallSites("if (!config || !config.confirm) return;")).toHaveLength(0);
+});

--- a/server/static/js/admin-api-tokens.js
+++ b/server/static/js/admin-api-tokens.js
@@ -327,7 +327,18 @@
   }
 
   async function _revokeToken(tokenId, label) {
-    if (!confirm(`確定撤銷此 Token？此操作無法復原。\n\n${label || tokenId}`)) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⊘",
+      title: "撤銷 API Token",
+      subtitle: "REVOKE · THIS ACTION CANNOT BE UNDONE",
+      severity: "danger",
+      body:
+        `<div style="line-height:1.7">使用此 Token 的整合會立即失去存取權。</div>` +
+        `<div style="margin-top:10px;font-family:var(--font-mono);font-size:12px;` +
+        `color:var(--color-text-muted)">${escapeHtml(label || tokenId)}</div>`,
+      confirmLabel: "撤銷",
+    });
+    if (!ok) return;
     try {
       const r = await csrfFetch(`/admin/api-tokens/${encodeURIComponent(tokenId)}`, {
         method: "DELETE",

--- a/server/static/js/admin-audience.js
+++ b/server/static/js/admin-audience.js
@@ -464,7 +464,7 @@
       title: "撤銷踢出",
       subtitle: "UNKICK · FINGERPRINT CAN SEND AGAIN",
       severity: "warn",
-      body: "該指紋之後又可以送出彈幕。<div style=\"margin-top:10px;font-family:var(--font-mono);font-size:12px;color:var(--color-text-muted)\">fp:" + fp.slice(0, 8) + "</div>",
+      body: "該指紋之後又可以送出彈幕。<div style=\"margin-top:10px;font-family:var(--font-mono);font-size:12px;color:var(--color-text-muted)\">fp:" + escapeHtml(fp.slice(0, 8)) + "</div>",
       confirmLabel: "撤銷踢出",
     });
     if (!ok) return;
@@ -544,7 +544,7 @@
       title: "封禁指紋",
       subtitle: "BAN FINGERPRINT · FUTURE MESSAGES AUTO-MASKED",
       severity: "danger",
-      body: "該指紋之後在本場發出的訊息會自動遮罩。<div style=\"margin-top:10px;font-family:var(--font-mono);font-size:12px;color:var(--color-text-muted)\">fp:" + fp.slice(0, 8) + "</div>",
+      body: "該指紋之後在本場發出的訊息會自動遮罩。<div style=\"margin-top:10px;font-family:var(--font-mono);font-size:12px;color:var(--color-text-muted)\">fp:" + escapeHtml(fp.slice(0, 8)) + "</div>",
       confirmLabel: "封禁",
     });
     if (!ok) return;

--- a/server/static/js/admin-audience.js
+++ b/server/static/js/admin-audience.js
@@ -459,7 +459,15 @@
 
   async function _unkick(fp) {
     if (!fp) return;
-    if (!confirm("撤銷對 fp:" + fp.slice(0, 8) + " 的踢出？該指紋之後又可送出彈幕。")) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "↩",
+      title: "撤銷踢出",
+      subtitle: "UNKICK · FINGERPRINT CAN SEND AGAIN",
+      severity: "warn",
+      body: "該指紋之後又可以送出彈幕。<div style=\"margin-top:10px;font-family:var(--font-mono);font-size:12px;color:var(--color-text-muted)\">fp:" + fp.slice(0, 8) + "</div>",
+      confirmLabel: "撤銷踢出",
+    });
+    if (!ok) return;
     try {
       const r = await window.csrfFetch("/admin/audience/unkick", {
         method: "POST",
@@ -531,7 +539,15 @@
 
   async function _ban(fp) {
     if (!fp || fp === "—") return;
-    if (!confirm("確定封禁指紋 fp:" + fp.slice(0, 8) + "？該指紋之後在本場發出的訊息會自動遮罩。")) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⊘",
+      title: "封禁指紋",
+      subtitle: "BAN FINGERPRINT · FUTURE MESSAGES AUTO-MASKED",
+      severity: "danger",
+      body: "該指紋之後在本場發出的訊息會自動遮罩。<div style=\"margin-top:10px;font-family:var(--font-mono);font-size:12px;color:var(--color-text-muted)\">fp:" + fp.slice(0, 8) + "</div>",
+      confirmLabel: "封禁",
+    });
+    if (!ok) return;
     try {
       const r = await window.csrfFetch("/admin/live/block", {
         method: "POST",

--- a/server/static/js/admin-backup.js
+++ b/server/static/js/admin-backup.js
@@ -333,7 +333,15 @@
       window.showToast && showToast("請先 Dry-run 通過後再套用", false);
       return;
     }
-    if (!confirm("套用設定快照會覆蓋目前同名設定。確定套用?")) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⚠",
+      title: "套用設定快照",
+      subtitle: "RESTORE SETTINGS · OVERWRITES MATCHING KEYS",
+      severity: "warn",
+      body: "快照中同名的設定會覆蓋目前的值，未包含在快照裡的設定維持不變。",
+      confirmLabel: "套用",
+    });
+    if (!ok) return;
 
     try {
       const res = await window.csrfFetch("/admin/settings/restore", {
@@ -373,7 +381,15 @@
   // ---- Zone 3 · Danger ----
 
   async function clearHistory() {
-    if (!confirm("確定清除所有彈幕歷史?此動作無法復原。")) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⊘",
+      title: "清除所有彈幕歷史",
+      subtitle: "CLEAR HISTORY · THIS ACTION CANNOT BE UNDONE",
+      severity: "danger",
+      body: "所有已歸檔的彈幕記錄會被刪除，無法復原。建議先下載完整快照。",
+      confirmLabel: "清除歷史",
+    });
+    if (!ok) return;
     try {
       const res = await window.csrfFetch("/admin/history/clear", { method: "POST" });
       if (res.ok) {
@@ -387,7 +403,15 @@
   }
 
   async function endSession() {
-    if (!confirm("確定登出目前管理員?")) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "→",
+      title: "登出管理員",
+      subtitle: "SIGN OUT · CURRENT SESSION ONLY",
+      severity: "info",
+      body: "只會結束你目前的管理員登入，不影響進行中的場次或 Desktop 顯示。",
+      confirmLabel: "登出",
+    });
+    if (!ok) return;
     try {
       const res = await window.csrfFetch("/logout", { method: "POST" });
       if (res.redirected) window.location.href = res.url;
@@ -416,7 +440,17 @@
       window.showToast && showToast("請輸入 reset 以確認", false);
       return;
     }
-    if (!confirm("Factory reset 會清除 runtime 狀態檔與目前佇列。請先下載完整快照。確定執行?")) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⊘",
+      title: "Factory reset",
+      subtitle: "FACTORY RESET · WIPES RUNTIME STATE AND QUEUE",
+      severity: "danger",
+      body:
+        "runtime 狀態檔與目前佇列都會被清除，無法復原。" +
+        "如果還沒下載完整快照，現在取消還來得及。",
+      confirmLabel: "執行 reset",
+    });
+    if (!ok) return;
     try {
       if (btn) btn.disabled = true;
       const res = await window.csrfFetch("/admin/backup/factory-reset", {
@@ -585,10 +619,18 @@
       window.showToast?.("請先 Dry-run 通過後再套用", false);
       return;
     }
-    if (!confirm(
-      "套用備份會覆蓋目前的 runtime/, effects/, plugins/, user_plugins/ — " +
-      "套用前已下載目前快照作為復原備案了嗎？"
-    )) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⚠",
+      title: "套用完整備份",
+      subtitle: "RESTORE PACK · OVERWRITES RUNTIME AND ASSETS",
+      severity: "danger",
+      body:
+        "會覆蓋目前的 <code>runtime/</code>、<code>effects/</code>、" +
+        "<code>plugins/</code>、<code>user_plugins/</code>。" +
+        "套用前已經下載目前的快照作為復原備案了嗎？",
+      confirmLabel: "套用備份",
+    });
+    if (!ok) return;
     const fd = new FormData();
     fd.append("file", _pendingPackFile);
     try {
@@ -692,9 +734,17 @@
       window.showToast?.("請先 Dry-run 通過後再套用", false);
       return;
     }
-    if (!confirm(
-      "套用素材包會覆蓋同名 emojis/, stickers/, sounds/ 檔案與 sticker pack metadata。確定套用?"
-    )) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⚠",
+      title: "套用素材包",
+      subtitle: "RESTORE ASSETS · OVERWRITES MATCHING FILES",
+      severity: "warn",
+      body:
+        "同名的 <code>emojis/</code>、<code>stickers/</code>、<code>sounds/</code> " +
+        "檔案與 sticker pack metadata 會被覆蓋。",
+      confirmLabel: "套用素材包",
+    });
+    if (!ok) return;
     const fd = new FormData();
     fd.append("file", _pendingAssetPackFile);
     try {

--- a/server/static/js/admin-broadcast.js
+++ b/server/static/js/admin-broadcast.js
@@ -395,8 +395,7 @@
       const elapsedStr = fmtDuration(elapsedMs);
       const msgs = _serverState.total_messages || 0;
       const fp = _uniqueFp.toLocaleString();
-      const ok = window.HudConfirm
-        ? await window.HudConfirm.open({
+      const ok = await window.HudConfirm?.open({
             icon: "■",
             title: "停止顯示",
             subtitle: "STOP DESKTOP · MESSAGES CONTINUE TO BE RECEIVED",
@@ -416,8 +415,7 @@
             confirmLabel: "停止顯示",
             cancelLabel: "取消",
             width: 440,
-          })
-        : confirm("確定要停止顯示嗎？訊息會繼續接收，但 Desktop 不再渲染。");
+          });
       if (!ok) return;
       // Stop overlay rendering; session lifecycle stays separate.
       const success = await postToggle("standby");
@@ -438,7 +436,15 @@
   }
 
   async function onClearClick() {
-    if (!confirm("清空 Desktop 螢幕上目前顯示的所有彈幕？")) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⌫",
+      title: "清空 Desktop 畫面",
+      subtitle: "CLEAR SCREEN · MESSAGES STAY ARCHIVED",
+      severity: "warn",
+      body: "只清掉目前顯示在 Desktop 上的彈幕，已歸檔的訊息記錄不受影響。",
+      confirmLabel: "清空畫面",
+    });
+    if (!ok) return;
     try {
       const r = await window.csrfFetch("/admin/overlay/clear", { method: "POST" });
       if (r.ok) window.showToast && showToast("已清空 Desktop", true);
@@ -449,7 +455,15 @@
   }
 
   async function onArchiveClick() {
-    if (!confirm("結束並存檔此場次？此操作無法復原。")) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "■",
+      title: "結束並存檔場次",
+      subtitle: "ARCHIVE SESSION · THIS ACTION CANNOT BE UNDONE",
+      severity: "danger",
+      body: "場次會被結束並歸檔，之後不能再往這個場次寫入訊息。",
+      confirmLabel: "結束場次",
+    });
+    if (!ok) return;
     try {
       const r = await window.csrfFetch("/admin/session/close", { method: "POST" });
       if (r.ok) {

--- a/server/static/js/admin-command-palette.js
+++ b/server/static/js/admin-command-palette.js
@@ -133,8 +133,16 @@
       id: "clear-history",
       label: "清空訊息歷史",
       sub: "POST /admin/history/clear · 危險",
-      action: () => {
-        if (!confirm("確定清空所有訊息歷史？此操作無法復原。")) return;
+      action: async () => {
+        const ok = await window.HudConfirm?.open({
+          icon: "⊘",
+          title: "清空訊息歷史",
+          subtitle: "CLEAR HISTORY · THIS ACTION CANNOT BE UNDONE",
+          severity: "danger",
+          body: "所有已歸檔的訊息記錄都會被刪除，無法復原。",
+          confirmLabel: "清空",
+        });
+        if (!ok) return;
         return _csrfFetch("/admin/history/clear", { method: "POST" })
           .then((r) => _toast(r.ok ? "訊息歷史已清空" : "清空失敗", r.ok))
           .catch(() => _toast("清空失敗", false));

--- a/server/static/js/admin-dashboard.js
+++ b/server/static/js/admin-dashboard.js
@@ -660,7 +660,7 @@
           body:
             `此 fingerprint 之後送出的訊息都會被擋下。` +
             `<div style="margin-top:10px;font-family:var(--font-mono);font-size:12px;` +
-            `color:var(--color-text-muted)">fp:${fp}</div>`,
+            `color:var(--color-text-muted)">fp:${_escapeHtml(fp)}</div>`,
           confirmLabel: "加入黑名單",
         });
         if (!ok) return;

--- a/server/static/js/admin-dashboard.js
+++ b/server/static/js/admin-dashboard.js
@@ -652,7 +652,18 @@
       const msgId = row.dataset.msgId;
       if (action === "blacklist") {
         if (!fp) { window.showToast && window.showToast("此訊息無 fingerprint，無法加入", false); return; }
-        if (!confirm(`加入黑名單 fp:${fp}？此 fingerprint 的後續訊息將被擋。`)) return;
+        const ok = await window.HudConfirm?.open({
+          icon: "⊘",
+          title: "加入黑名單",
+          subtitle: "BLACKLIST FINGERPRINT · BLOCKS FUTURE MESSAGES",
+          severity: "danger",
+          body:
+            `此 fingerprint 之後送出的訊息都會被擋下。` +
+            `<div style="margin-top:10px;font-family:var(--font-mono);font-size:12px;` +
+            `color:var(--color-text-muted)">fp:${fp}</div>`,
+          confirmLabel: "加入黑名單",
+        });
+        if (!ok) return;
         try {
           const r = await window.csrfFetch("/admin/blacklist/add", {
             method: "POST",
@@ -902,7 +913,15 @@
         btn.disabled = false;
       }
     } else if (action === "close") {
-      if (!confirm("確定要結束這個場次？\n訊息將停止歸檔，Desktop 將切換為 OFF。")) return;
+      const ok = await window.HudConfirm?.open({
+        icon: "■",
+        title: "結束場次",
+        subtitle: "CLOSE SESSION · DESKTOP SWITCHES OFF",
+        severity: "danger",
+        body: "訊息會停止歸檔，Desktop 顯示切換為 OFF。",
+        confirmLabel: "結束場次",
+      });
+      if (!ok) return;
       btn.disabled = true;
       try {
         const r = await window.csrfFetch("/admin/session/close", { method: "POST" });

--- a/server/static/js/admin-display.js
+++ b/server/static/js/admin-display.js
@@ -797,7 +797,14 @@
       FontFamily: [false, "", "", "NotoSansTC"],
       Layout:     [true, "", "", "scroll"],
     };
-    const ok = window.confirm(t("displayRevertConfirm", "還原預設將覆寫目前設定，確定？"));
+    const ok = await window.HudConfirm?.open({
+      icon: "↩",
+      title: "還原預設值",
+      subtitle: "REVERT TO DEFAULTS · OVERWRITES CURRENT SETTINGS",
+      severity: "warn",
+      body: t("displayRevertConfirm", "還原預設將覆寫目前設定，確定？"),
+      confirmLabel: "還原預設",
+    });
     if (!ok) return;
     try {
       for (const [k, target] of Object.entries(presets)) {

--- a/server/static/js/admin-effects-mgmt.js
+++ b/server/static/js/admin-effects-mgmt.js
@@ -775,10 +775,8 @@
       // ── Delete handler
       delBtn.addEventListener("click", async () => {
         // 2026-05-18 design v4-r2 DeleteConfirm: use HudConfirm modal if
-        // helper has loaded, fall back to native confirm() otherwise.
         const effName = eff.label || eff.name;
-        const ok = window.HudConfirm
-          ? await window.HudConfirm.open({
+        const ok = await window.HudConfirm?.open({
               icon: "⊗",
               title: "刪除確認",
               subtitle: "DELETE · THIS ACTION CANNOT BE UNDONE",
@@ -793,8 +791,7 @@
               confirmLabel: "確認刪除",
               cancelLabel: "取消",
               width: 400,
-            })
-          : confirm(ServerI18n.t("deleteEffectConfirm").replace("{name}", effName));
+            });
         if (!ok) return;
         try {
           const res = await csrfFetch("/admin/effects/delete", {

--- a/server/static/js/admin-emojis.js
+++ b/server/static/js/admin-emojis.js
@@ -300,7 +300,15 @@
   // ─── Delete ────────────────────────────────────────────────────────
 
   async function handleDelete(name) {
-    if (!confirm(ServerI18n.t("deleteEmojiConfirm").replace("{name}", name))) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⊘",
+      title: "刪除表情",
+      subtitle: "DELETE EMOJI",
+      severity: "danger",
+      body: ServerI18n.t("deleteEmojiConfirm").replace("{name}", name),
+      confirmLabel: "刪除",
+    });
+    if (!ok) return;
 
     try {
       var resp = await csrfFetch("/admin/emojis/delete", {

--- a/server/static/js/admin-emojis.js
+++ b/server/static/js/admin-emojis.js
@@ -305,7 +305,7 @@
       title: "刪除表情",
       subtitle: "DELETE EMOJI",
       severity: "danger",
-      body: ServerI18n.t("deleteEmojiConfirm").replace("{name}", name),
+      bodyText: ServerI18n.t("deleteEmojiConfirm").replace("{name}", name),
       confirmLabel: "刪除",
     });
     if (!ok) return;

--- a/server/static/js/admin-extensions.js
+++ b/server/static/js/admin-extensions.js
@@ -172,7 +172,15 @@
   }
 
   async function _regenerateToken() {
-    if (!confirm("產生新的 Fire Token 會讓現有 extension 立即失效，要繼續嗎？")) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⟳",
+      title: "重新產生 Fire Token",
+      subtitle: "ROTATE · EXISTING EXTENSIONS STOP WORKING IMMEDIATELY",
+      severity: "warn",
+      body: "目前所有使用舊 Token 的 extension 會立刻失去存取權，需要重新設定新的 Token。",
+      confirmLabel: "產生新 Token",
+    });
+    if (!ok) return;
     try {
       const r = await window.csrfFetch("/admin/integrations/fire-token/regenerate", { method: "POST" });
       if (!r.ok) throw new Error("HTTP " + r.status);
@@ -194,7 +202,15 @@
   }
 
   async function _revokeToken() {
-    if (!confirm("撤銷 Fire Token 會立刻停用所有 extension，要繼續嗎？")) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⊘",
+      title: "撤銷 Fire Token",
+      subtitle: "REVOKE · ALL EXTENSIONS STOP WORKING",
+      severity: "danger",
+      body: "所有 extension 會立即停止運作，直到你產生新的 Token 並重新設定它們。",
+      confirmLabel: "撤銷",
+    });
+    if (!ok) return;
     try {
       const r = await window.csrfFetch("/admin/integrations/fire-token/revoke", { method: "POST" });
       if (!r.ok) throw new Error("HTTP " + r.status);

--- a/server/static/js/admin-filters.js
+++ b/server/static/js/admin-filters.js
@@ -386,7 +386,15 @@
   }
 
   async function deleteRule(ruleId) {
-    if (!confirm(t("confirmDeleteRule", "Delete this filter rule?"))) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⊘",
+      title: "刪除過濾規則",
+      subtitle: "DELETE FILTER RULE",
+      severity: "danger",
+      body: t("confirmDeleteRule", "Delete this filter rule?"),
+      confirmLabel: "刪除",
+    });
+    if (!ok) return;
     try {
       const resp = await csrfFetch("/admin/filters/remove", {
         method: "POST",

--- a/server/static/js/admin-fingerprints.js
+++ b/server/static/js/admin-fingerprints.js
@@ -149,7 +149,15 @@
   }
 
   async function handleReset() {
-    if (!confirm(ServerI18n.t("fingerprintResetConfirm"))) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⟳",
+      title: "重設指紋統計",
+      subtitle: "RESET FINGERPRINTS · OBSERVED DATA IS CLEARED",
+      severity: "danger",
+      body: ServerI18n.t("fingerprintResetConfirm"),
+      confirmLabel: "重設",
+    });
+    if (!ok) return;
     try {
       var resp = await window.csrfFetch("/admin/fingerprints/reset", {
         method: "POST",

--- a/server/static/js/admin-firetoken.js
+++ b/server/static/js/admin-firetoken.js
@@ -171,7 +171,15 @@
   // ── actions ────────────────────────────────────────────────────────
 
   async function _regenerate() {
-    if (!confirm("產生新的 Fire Token 會讓現有 extension 立即失效，要繼續嗎？")) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⟳",
+      title: "重新產生 Fire Token",
+      subtitle: "ROTATE · EXISTING EXTENSIONS STOP WORKING IMMEDIATELY",
+      severity: "warn",
+      body: "目前所有使用舊 Token 的 extension 會立刻失去存取權，需要重新設定新的 Token。",
+      confirmLabel: "產生新 Token",
+    });
+    if (!ok) return;
     try {
       const r = await window.csrfFetch("/admin/integrations/fire-token/regenerate", { method: "POST" });
       if (!r.ok) throw new Error("HTTP " + r.status);
@@ -194,7 +202,15 @@
   }
 
   async function _revoke() {
-    if (!confirm("撤銷會立即停用所有 extension，要繼續嗎？")) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⊘",
+      title: "撤銷 Fire Token",
+      subtitle: "REVOKE · ALL EXTENSIONS STOP WORKING",
+      severity: "danger",
+      body: "所有 extension 會立即停止運作，直到你產生新的 Token 並重新設定它們。",
+      confirmLabel: "撤銷",
+    });
+    if (!ok) return;
     try {
       const r = await window.csrfFetch("/admin/integrations/fire-token/revoke", { method: "POST" });
       if (!r.ok) throw new Error("HTTP " + r.status);

--- a/server/static/js/admin-fonts.js
+++ b/server/static/js/admin-fonts.js
@@ -652,7 +652,7 @@
       title: "刪除字型",
       subtitle: "DELETE FONT",
       severity: "danger",
-      body: ServerI18n.t("deleteFontConfirm").replace("{name}", name),
+      bodyText: ServerI18n.t("deleteFontConfirm").replace("{name}", name),
       confirmLabel: "刪除",
     });
     if (!ok) return;

--- a/server/static/js/admin-fonts.js
+++ b/server/static/js/admin-fonts.js
@@ -647,7 +647,15 @@
   }
 
   async function handleDelete(name) {
-    if (!confirm(ServerI18n.t("deleteFontConfirm").replace("{name}", name))) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⊘",
+      title: "刪除字型",
+      subtitle: "DELETE FONT",
+      severity: "danger",
+      body: ServerI18n.t("deleteFontConfirm").replace("{name}", name),
+      confirmLabel: "刪除",
+    });
+    if (!ok) return;
     try {
       var resp = await window.csrfFetch("/admin/fonts/" + encodeURIComponent(name), { method: "DELETE" });
       var data = await resp.json();

--- a/server/static/js/admin-history.js
+++ b/server/static/js/admin-history.js
@@ -121,7 +121,7 @@
       title: "移除黑名單關鍵字",
       subtitle: "REMOVE KEYWORD",
       severity: "warn",
-      body: ServerI18n.t("confirmRemoveKeyword").replace("{keyword}", keyword),
+      bodyText: ServerI18n.t("confirmRemoveKeyword").replace("{keyword}", keyword),
       confirmLabel: "移除",
     });
     if (!ok) return;

--- a/server/static/js/admin-history.js
+++ b/server/static/js/admin-history.js
@@ -116,7 +116,15 @@
   }
 
   async function removeKeyword(keyword) {
-    if (!confirm(ServerI18n.t("confirmRemoveKeyword").replace("{keyword}", keyword))) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⊘",
+      title: "移除黑名單關鍵字",
+      subtitle: "REMOVE KEYWORD",
+      severity: "warn",
+      body: ServerI18n.t("confirmRemoveKeyword").replace("{keyword}", keyword),
+      confirmLabel: "移除",
+    });
+    if (!ok) return;
     try {
       const response = await window.csrfFetch("/admin/blacklist/remove", {
         method: "POST",
@@ -320,9 +328,15 @@
   }
 
   async function clearDanmuHistory() {
-    if (
-      !confirm(ServerI18n.t("confirmClearHistory"))
-    ) {
+    const ok = await window.HudConfirm?.open({
+      icon: "⊘",
+      title: "清除彈幕歷史",
+      subtitle: "CLEAR HISTORY · THIS ACTION CANNOT BE UNDONE",
+      severity: "danger",
+      body: ServerI18n.t("confirmClearHistory"),
+      confirmLabel: "清除",
+    });
+    if (!ok) {
       return;
     }
 

--- a/server/static/js/admin-hud-modal.js
+++ b/server/static/js/admin-hud-modal.js
@@ -92,6 +92,12 @@
         subtitle = "",
         severity = "warn",
         body = "",
+        // Safe text variants. `title` / `body` go through innerHTML so callers
+        // can pass rich markup; anything user-controlled (message text, an
+        // uploaded filename, a keyword) must come in through these instead —
+        // they are written with textContent and can never execute.
+        titleText,
+        bodyText,
         confirmLabel = "確認",
         cancelLabel = "取消",
         width = 480,
@@ -127,6 +133,15 @@
             <button type="button" class="admin-hud-modal__btn admin-hud-modal__btn--confirm" data-modal-action="confirm">${confirmLabel}</button>
           </div>
         </div>`;
+
+      if (titleText != null) {
+        const titleEl = root.querySelector(".admin-hud-modal__title");
+        if (titleEl) titleEl.textContent = String(titleText);
+      }
+      if (bodyText != null) {
+        const bodyEl = root.querySelector("[data-modal-body]");
+        if (bodyEl) bodyEl.textContent = String(bodyText);
+      }
 
       if (wantsBodyNode) {
         const bodyEl = root.querySelector("[data-modal-body]");

--- a/server/static/js/admin-hud-modal.js
+++ b/server/static/js/admin-hud-modal.js
@@ -150,5 +150,11 @@
     });
   }
 
+  // Call sites use `await window.HudConfirm?.open({…})`. The optional chaining
+  // matters: if this script somehow didn't load, the expression is `undefined`
+  // — falsy — so a destructive action is treated as cancelled. Falling back to
+  // native `confirm()` (which several modules used to do) both reintroduces
+  // the dialog this module replaces and answers "delete everything?" with a
+  // prompt instead of a no.
   window.HudConfirm = { open };
 })();

--- a/server/static/js/admin-live-feed.js
+++ b/server/static/js/admin-live-feed.js
@@ -238,7 +238,7 @@
       title: "封鎖",
       subtitle: "BLOCK · FUTURE MESSAGES ARE FILTERED",
       severity: "danger",
-      body: ServerI18n.t("blockConfirm").replace("{label}", label).replace("{display}", display),
+      bodyText: ServerI18n.t("blockConfirm").replace("{label}", label).replace("{display}", display),
       confirmLabel: "封鎖",
     });
     if (!ok) return;

--- a/server/static/js/admin-live-feed.js
+++ b/server/static/js/admin-live-feed.js
@@ -233,7 +233,15 @@
     const display =
       type === "keyword" ? truncate(value, 30) : value.slice(0, FP_DISPLAY_LEN);
 
-    if (!confirm(ServerI18n.t("blockConfirm").replace("{label}", label).replace("{display}", display))) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⊘",
+      title: "封鎖",
+      subtitle: "BLOCK · FUTURE MESSAGES ARE FILTERED",
+      severity: "danger",
+      body: ServerI18n.t("blockConfirm").replace("{label}", label).replace("{display}", display),
+      confirmLabel: "封鎖",
+    });
+    if (!ok) return;
 
     try {
       const resp = await window.csrfFetch("/admin/live/block", {
@@ -271,7 +279,15 @@
       .map((id) => entries.find((e) => e.id === id))
       .filter(Boolean);
     if (targets.length === 0) return;
-    if (!confirm(`批次遮罩 ${targets.length} 則訊息 (依指紋)?`)) return;
+    const confirmed = await window.HudConfirm?.open({
+      icon: "⊘",
+      title: "批次遮罩訊息",
+      subtitle: "BULK MASK · BY FINGERPRINT",
+      severity: "danger",
+      body: `將依指紋遮罩 <b>${targets.length}</b> 則訊息。`,
+      confirmLabel: "批次遮罩",
+    });
+    if (!confirmed) return;
 
     let ok = 0;
     for (const t of targets) {

--- a/server/static/js/admin-message-drawer.js
+++ b/server/static/js/admin-message-drawer.js
@@ -334,13 +334,7 @@
       </div>
       <div class="admin-bancfm-warn">⚠ 該指紋下所有訊息將被遮罩，該指紋將被加入黑名單。</div>`;
 
-    if (!window.HudConfirm) {
-      // Fallback to native confirm if helper hasn't loaded yet.
-      if (confirm("確定封禁此指紋？該指紋之後在本場發出的訊息會自動遮罩。")) {
-        return _banFingerprint("");
-      }
-      return;
-    }
+    if (!window.HudConfirm) return;
     const ok = await window.HudConfirm.open({
       icon: "⊘",
       title: "封禁確認",
@@ -370,7 +364,15 @@
     // /admin/live/block with type=keyword on the message text).
     const text = _state.entry && _state.entry.data && _state.entry.data.text;
     if (!text) return;
-    if (!confirm("把此訊息加入黑名單關鍵字？")) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⊘",
+      title: "加入黑名單關鍵字",
+      subtitle: "BLACKLIST KEYWORD · FUTURE MATCHES BLOCKED",
+      severity: "danger",
+      body: "之後包含這段文字的訊息都會被擋下。",
+      confirmLabel: "加入黑名單",
+    });
+    if (!ok) return;
     try {
       const r = await window.csrfFetch("/admin/live/block", {
         method: "POST",

--- a/server/static/js/admin-modqueue.js
+++ b/server/static/js/admin-modqueue.js
@@ -307,7 +307,7 @@
   function _bind() {
     const root = document.getElementById(SECTION_ID);
     if (!root) return;
-    root.addEventListener("click", (e) => {
+    root.addEventListener("click", async (e) => {
       const a = e.target.closest("[data-mq-action]");
       if (a) {
         const id = a.dataset.mqId;
@@ -318,7 +318,17 @@
       const b = e.target.closest("[data-mq-bulk]");
       if (b) {
         const kind = b.dataset.mqBulk;
-        const ok = confirm(kind === "approve-low" ? "通過所有 LOW 嚴重度的訊息？" : "拒絕所有 HIGH 嚴重度的訊息？");
+        const approving = kind === "approve-low";
+        const ok = await window.HudConfirm?.open({
+          icon: approving ? "✓" : "⊘",
+          title: approving ? "通過所有 LOW 訊息" : "拒絕所有 HIGH 訊息",
+          subtitle: "BULK MODERATION · APPLIES TO THE WHOLE QUEUE",
+          severity: approving ? "warn" : "danger",
+          body: approving
+            ? "佇列中所有 LOW 嚴重度的待審訊息都會被放行。"
+            : "佇列中所有 HIGH 嚴重度的待審訊息都會被拒絕。",
+          confirmLabel: approving ? "全部通過" : "全部拒絕",
+        });
         if (!ok) return;
         const action = kind.startsWith("approve") ? "approve" : "reject";
         const severity = kind.endsWith("low") ? "low" : "high";

--- a/server/static/js/admin-plugins.js
+++ b/server/static/js/admin-plugins.js
@@ -345,10 +345,10 @@
     async function uninstallPlugin(name, filename) {
       const ok = await window.HudConfirm?.open({
         icon: "⊘",
-        title: `移除插件「${name}」`,
+        titleText: `移除插件「${name}」`,
         subtitle: "UNINSTALL PLUGIN · FILE IS DELETED",
         severity: "danger",
-        body: `檔案 <code>server/user_plugins/${filename}</code> 會被刪除，無法復原。`,
+        bodyText: `檔案 server/user_plugins/${filename} 會被刪除，無法復原。`,
         confirmLabel: "移除插件",
       });
       if (!ok) return;

--- a/server/static/js/admin-plugins.js
+++ b/server/static/js/admin-plugins.js
@@ -343,7 +343,15 @@
     }
 
     async function uninstallPlugin(name, filename) {
-      if (!confirm(`確定移除插件「${name}」？\n\n檔案 server/user_plugins/${filename} 會被刪除，無法復原。`)) return;
+      const ok = await window.HudConfirm?.open({
+        icon: "⊘",
+        title: `移除插件「${name}」`,
+        subtitle: "UNINSTALL PLUGIN · FILE IS DELETED",
+        severity: "danger",
+        body: `檔案 <code>server/user_plugins/${filename}</code> 會被刪除，無法復原。`,
+        confirmLabel: "移除插件",
+      });
+      if (!ok) return;
       try {
         const res = await csrfFetch("/admin/plugins/uninstall", {
           method: "POST",

--- a/server/static/js/admin-poll-builder.js
+++ b/server/static/js/admin-poll-builder.js
@@ -758,7 +758,7 @@
         if (e.target.matches("[data-ed-timer]")) { q.timer = +e.target.value; persist(); renderQueue(); }
         else if (e.target.matches("[data-ed-multi]")) { q.multi = e.target.checked; persist(); }
       });
-      editorEl.addEventListener("click", (e) => {
+      editorEl.addEventListener("click", async (e) => {
         const q = findQ(activeId);
         if (!q) return;
         const cropBtn = e.target.closest("[data-ed-crop]");
@@ -782,11 +782,21 @@
         const act = e.target.closest("[data-ed-action]");
         if (act) {
           if (act.dataset.edAction === "remove-q") {
-            if (queue.length > 1 && confirm("刪除此題目?")) {
-              const idx = queue.findIndex(q2 => q2.id === activeId);
-              queue = queue.filter(q2 => q2.id !== activeId);
-              activeId = queue[Math.min(idx, queue.length - 1)].id;
-              persist(); render();
+            if (queue.length > 1) {
+              const ok = await window.HudConfirm?.open({
+                icon: "⊘",
+                title: "刪除題目",
+                subtitle: "REMOVE QUESTION · DRAFT ONLY",
+                severity: "warn",
+                body: "從這份草稿中移除目前這一題。尚未開始的投票不受影響。",
+                confirmLabel: "刪除題目",
+              });
+              if (ok) {
+                const idx = queue.findIndex(q2 => q2.id === activeId);
+                queue = queue.filter(q2 => q2.id !== activeId);
+                activeId = queue[Math.min(idx, queue.length - 1)].id;
+                persist(); render();
+              }
             }
           } else if (act.dataset.edAction === "start-this") {
             startAt(queue.findIndex(q2 => q2.id === activeId));

--- a/server/static/js/admin-security.js
+++ b/server/static/js/admin-security.js
@@ -511,7 +511,15 @@
   }
 
   async function rotateWsAuth() {
-    if (!confirm("將產生全新 token,舊 token 立即失效。繼續?")) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⟳",
+      title: "重設 WS Token",
+      subtitle: "ROTATE WS TOKEN · DESKTOP MUST RECONNECT",
+      severity: "warn",
+      body: "舊 token 立即失效，Desktop 需要用新 token 重新連線。",
+      confirmLabel: "產生新 token",
+    });
+    if (!ok) return;
     try {
       const res = await window.csrfFetch("/admin/ws-auth/rotate", { method: "POST" });
       const data = await res.json().catch(() => ({}));
@@ -566,7 +574,16 @@
         ok: () => "WS Token 已重設",
       },
     }[action];
-    if (!config || !confirm(config.confirm)) return;
+    if (!config) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⚠",
+      title: config.title || "確認操作",
+      subtitle: config.subtitle || "SECURITY ACTION",
+      severity: config.severity || "warn",
+      body: config.confirm,
+      confirmLabel: config.confirmLabel || "確認",
+    });
+    if (!ok) return;
     try {
       const res = await window.csrfFetch(config.url, { method: "POST" });
       const data = await res.json().catch(() => ({}));

--- a/server/static/js/admin-sounds.js
+++ b/server/static/js/admin-sounds.js
@@ -141,7 +141,7 @@
           title: "刪除音效",
           subtitle: "DELETE SOUND",
           severity: "danger",
-          body: ServerI18n.t("deleteSoundConfirm").replace("{name}", name),
+          bodyText: ServerI18n.t("deleteSoundConfirm").replace("{name}", name),
           confirmLabel: "刪除",
         });
         if (!ok) return;

--- a/server/static/js/admin-sounds.js
+++ b/server/static/js/admin-sounds.js
@@ -136,7 +136,15 @@
     container.querySelectorAll(".sound-delete-btn").forEach(function (btn) {
       btn.addEventListener("click", async function () {
         var name = btn.dataset.name;
-        if (!confirm(ServerI18n.t("deleteSoundConfirm").replace("{name}", name))) return;
+        const ok = await window.HudConfirm?.open({
+          icon: "⊘",
+          title: "刪除音效",
+          subtitle: "DELETE SOUND",
+          severity: "danger",
+          body: ServerI18n.t("deleteSoundConfirm").replace("{name}", name),
+          confirmLabel: "刪除",
+        });
+        if (!ok) return;
         try {
           await deleteSound(name);
           window.showToast(ServerI18n.t("soundDeleted").replace("{name}", name), true);

--- a/server/static/js/admin-stickers.js
+++ b/server/static/js/admin-stickers.js
@@ -261,7 +261,15 @@
       return;
     }
     if (action === "delete") {
-      if (!confirm("確定刪除此貼圖包?所有貼圖都會一起刪除。")) return;
+      const ok = await window.HudConfirm?.open({
+        icon: "⊘",
+        title: "刪除貼圖包",
+        subtitle: "DELETE PACK · ALL STICKERS INSIDE ARE REMOVED",
+        severity: "danger",
+        body: "這個貼圖包內的所有貼圖都會一起刪除，無法復原。",
+        confirmLabel: "刪除貼圖包",
+      });
+      if (!ok) return;
       try {
         var dr = await window.csrfFetch("/admin/stickers/packs/" + encodeURIComponent(packId), {
           method: "DELETE",
@@ -384,7 +392,15 @@
   // ─── Delete ────────────────────────────────────────────────────────
 
   async function handleDelete(name) {
-    if (!confirm(ServerI18n.t("deleteStickerConfirm").replace("{name}", name))) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⊘",
+      title: "刪除貼圖",
+      subtitle: "DELETE STICKER",
+      severity: "danger",
+      body: ServerI18n.t("deleteStickerConfirm").replace("{name}", name),
+      confirmLabel: "刪除",
+    });
+    if (!ok) return;
     try {
       var resp = await window.csrfFetch("/admin/stickers/" + encodeURIComponent(name), {
         method: "DELETE",

--- a/server/static/js/admin-stickers.js
+++ b/server/static/js/admin-stickers.js
@@ -397,7 +397,7 @@
       title: "刪除貼圖",
       subtitle: "DELETE STICKER",
       severity: "danger",
-      body: ServerI18n.t("deleteStickerConfirm").replace("{name}", name),
+      bodyText: ServerI18n.t("deleteStickerConfirm").replace("{name}", name),
       confirmLabel: "刪除",
     });
     if (!ok) return;

--- a/server/static/js/admin-webhooks.js
+++ b/server/static/js/admin-webhooks.js
@@ -628,7 +628,15 @@
 
   async function _deleteWebhook(hookId) {
     if (!hookId) return;
-    if (!confirm(ServerI18n.t("deleteWebhookConfirm") || "確定刪除這個 webhook？")) return;
+    const ok = await window.HudConfirm?.open({
+      icon: "⊘",
+      title: "刪除 webhook",
+      subtitle: "DELETE WEBHOOK",
+      severity: "danger",
+      body: ServerI18n.t("deleteWebhookConfirm") || "確定刪除這個 webhook？",
+      confirmLabel: "刪除",
+    });
+    if (!ok) return;
     try {
       const res = await csrfFetch("/admin/webhooks/unregister", {
         method: "POST",

--- a/server/static/js/admin-widgets.js
+++ b/server/static/js/admin-widgets.js
@@ -192,7 +192,15 @@
 
     async function deleteWidget(id) {
       const t = window.ServerI18n?.t?.("widgetDeleteConfirm") || "刪除這個小工具?";
-      if (!confirm(t)) return;
+      const ok = await window.HudConfirm?.open({
+        icon: "⊘",
+        title: "刪除小工具",
+        subtitle: "DELETE WIDGET",
+        severity: "danger",
+        body: t,
+        confirmLabel: "刪除",
+      });
+      if (!ok) return;
       try {
         await api("delete", "POST", { id });
         loadWidgets();
@@ -221,7 +229,15 @@
 
     async function clearAllWidgets() {
       const t = window.ServerI18n?.t?.("widgetClearConfirm") || "清除所有小工具?";
-      if (!confirm(t)) return;
+      const ok = await window.HudConfirm?.open({
+        icon: "⊘",
+        title: "清除所有小工具",
+        subtitle: "CLEAR ALL WIDGETS · THIS ACTION CANNOT BE UNDONE",
+        severity: "danger",
+        body: t,
+        confirmLabel: "全部清除",
+      });
+      if (!ok) return;
       try {
         await api("clear", "POST", {});
         loadWidgets();

--- a/server/tests/test_browser_admin.py
+++ b/server/tests/test_browser_admin.py
@@ -683,6 +683,142 @@ def test_modqueue_does_not_storm_the_list_endpoint(admin_page):
     )
 
 
+# ─── 破壞性動作的 HUD 確認面板 ────────────────────────────────────────────────
+#
+# 2026-07-26：admin 的 43 處原生 confirm() 全部改走 HudConfirm modal。改動面很
+# 廣（25 個模組），但絕大多數只有「語法能過 + 載入沒有 console error」這層保護。
+# 這裡替最不能出錯的幾條路徑補上真正的點擊驗證。
+#
+# 每條測的是同一組不變式：
+#   1. 按下去會出現 HUD 面板（而不是原生對話框，也不是什麼都沒發生）
+#   2. 按取消 → 不送出任何 API 請求 —— 這正是改寫時每處都寫的 `if (!ok) return;`
+#   3. 面板上寫著這個動作的後果（title / subtitle 有掛對）
+#
+# 「確認會不會真的送出」只在清除歷史那條驗證：live_url 是 session-scoped，真的
+# 執行 factory reset 或撤銷 token 會污染同模組後面的測試。
+
+
+def _dialog_recorder(page):
+    """記錄原生對話框。改寫之後這個清單必須永遠是空的。"""
+    seen = []
+
+    def _on_dialog(dialog):
+        seen.append(dialog.message)
+        dialog.dismiss()
+
+    page.on("dialog", _on_dialog)
+    return seen
+
+
+def _open_backup_page(page):
+    page.evaluate('() => { window.location.hash = "#/backup"; }')
+    page.wait_for_selector("#bk2-clear-history", state="visible", timeout=8000)
+
+
+def test_clear_history_shows_hud_panel_and_cancel_sends_nothing(admin_page):
+    """清除彈幕歷史：出現 HUD 面板；取消不送請求；確認才送。"""
+    dialogs = _dialog_recorder(admin_page)
+    calls = []
+    admin_page.on(
+        "request",
+        lambda r: calls.append(r.url) if "/admin/history/clear" in r.url else None,
+    )
+    _open_backup_page(admin_page)
+
+    admin_page.locator("#bk2-clear-history").click()
+    panel = admin_page.locator(".admin-hud-modal__panel")
+    panel.wait_for(state="visible", timeout=5000)
+    assert "清除所有彈幕歷史" in panel.inner_text()
+    assert "CANNOT BE UNDONE" in panel.inner_text()
+
+    admin_page.locator(".admin-hud-modal__btn--cancel").click()
+    admin_page.wait_for_timeout(600)
+    assert calls == [], f"取消之後仍然送出了請求：{calls}"
+
+    # 確認路徑：這次真的讓它跑完（清空測試 server 的歷史，無副作用）。
+    admin_page.locator("#bk2-clear-history").click()
+    panel.wait_for(state="visible", timeout=5000)
+    admin_page.locator(".admin-hud-modal__btn--confirm").click()
+    admin_page.wait_for_timeout(1000)
+    assert len(calls) == 1, f"確認之後應該剛好送出一次請求，實際 {len(calls)} 次"
+
+    assert dialogs == [], f"仍然跳出了原生對話框：{dialogs}"
+
+
+def test_factory_reset_shows_hud_panel_and_cancel_sends_nothing(admin_page):
+    """Factory reset：最危險的一顆按鈕，取消必須什麼都不做。"""
+    dialogs = _dialog_recorder(admin_page)
+    calls = []
+    admin_page.on(
+        "request",
+        lambda r: calls.append(r.url) if "/admin/backup/factory-reset" in r.url else None,
+    )
+    _open_backup_page(admin_page)
+
+    # 按鈕預設 disabled，要在確認框輸入 reset 才會啟用。
+    admin_page.fill("#bk2-factory-confirm", "reset")
+    admin_page.dispatch_event("#bk2-factory-confirm", "input")
+    admin_page.locator("#bk2-factory-reset").click()
+
+    panel = admin_page.locator(".admin-hud-modal__panel")
+    panel.wait_for(state="visible", timeout=5000)
+    assert "Factory reset" in panel.inner_text()
+    assert "WIPES RUNTIME STATE" in panel.inner_text()
+
+    admin_page.locator(".admin-hud-modal__btn--cancel").click()
+    admin_page.wait_for_timeout(600)
+    assert calls == [], f"取消 factory reset 之後仍然送出了請求：{calls}"
+    assert dialogs == [], f"仍然跳出了原生對話框：{dialogs}"
+
+
+def test_revoke_fire_token_shows_hud_panel_and_cancel_sends_nothing(admin_page, live_url):
+    """撤銷 Fire Token：撤銷鍵要先有 token 才會啟用，取消必須什麼都不做。"""
+    dialogs = _dialog_recorder(admin_page)
+    calls = []
+    admin_page.on(
+        "request",
+        lambda r: calls.append(r.url) if "fire-token/revoke" in r.url else None,
+    )
+
+    # 先產生一個 token，撤銷鍵才會從 disabled 解開。
+    admin_page.evaluate("""async () => {
+            const token = document.querySelector('meta[name="csrf-token"]')?.content || "";
+            await fetch("/admin/integrations/fire-token/regenerate", {
+                method: "POST",
+                credentials: "include",
+                headers: { "X-CSRF-Token": token },
+            });
+        }""")
+    # extensions 模組只在 init() 時讀一次 token 狀態，所以剛才那個 regenerate
+    # 之後必須讓整頁重新載入，它手上才會是新的快照 —— 否則撤銷鍵一直 disabled。
+    #
+    # 這裡一定要用 reload()：goto() 到只有 hash 不同的網址並不會重新載入頁面，
+    # init() 不會再跑，看起來像修好了其實沒有。本機因為 runtime/fire_token.json
+    # 留著，第一次載入就抓到 has_token，反而掩蓋這個差別；CI 的乾淨環境會炸。
+    admin_page.evaluate('() => { window.location.hash = "#/extensions"; }')
+    admin_page.reload()
+    revoke = admin_page.locator('[data-fire-token-action="revoke"]')
+    revoke.wait_for(state="visible", timeout=8000)
+    admin_page.wait_for_function(
+        """() => {
+            const b = document.querySelector('[data-fire-token-action="revoke"]');
+            return b && !b.disabled;
+        }""",
+        timeout=8000,
+    )
+
+    revoke.click()
+    panel = admin_page.locator(".admin-hud-modal__panel")
+    panel.wait_for(state="visible", timeout=5000)
+    assert "撤銷 Fire Token" in panel.inner_text()
+    assert "ALL EXTENSIONS STOP WORKING" in panel.inner_text()
+
+    admin_page.locator(".admin-hud-modal__btn--cancel").click()
+    admin_page.wait_for_timeout(600)
+    assert calls == [], f"取消撤銷之後仍然送出了請求：{calls}"
+    assert dialogs == [], f"仍然跳出了原生對話框：{dialogs}"
+
+
 # ─── Metrics API ───────────────────────────────────────────────────────────────
 
 

--- a/server/tests/test_browser_admin.py
+++ b/server/tests/test_browser_admin.py
@@ -813,10 +813,85 @@ def test_revoke_fire_token_shows_hud_panel_and_cancel_sends_nothing(admin_page, 
     assert "撤銷 Fire Token" in panel.inner_text()
     assert "ALL EXTENSIONS STOP WORKING" in panel.inner_text()
 
-    admin_page.locator(".admin-hud-modal__btn--cancel").click()
-    admin_page.wait_for_timeout(600)
-    assert calls == [], f"取消撤銷之後仍然送出了請求：{calls}"
-    assert dialogs == [], f"仍然跳出了原生對話框：{dialogs}"
+    try:
+        admin_page.locator(".admin-hud-modal__btn--cancel").click()
+        admin_page.wait_for_timeout(600)
+        assert calls == [], f"取消撤銷之後仍然送出了請求：{calls}"
+        assert dialogs == [], f"仍然跳出了原生對話框：{dialogs}"
+    finally:
+        # 這個測試真的產生了一個會寫進 runtime/fire_token.json 的 token，而
+        # live_url 是 session-scoped —— 不收掉的話，同模組後面的測試會繼承一個
+        # has_token=true 的狀態。收在 finally，斷言失敗時也照樣清乾淨。
+        admin_page.evaluate("""async () => {
+                const token = document.querySelector('meta[name="csrf-token"]')?.content || "";
+                await fetch("/admin/integrations/fire-token/revoke", {
+                    method: "POST",
+                    credentials: "include",
+                    headers: { "X-CSRF-Token": token },
+                }).catch(() => {});
+            }""")
+
+
+def test_hud_confirm_never_executes_markup_from_dynamic_text(admin_page):
+    """HudConfirm 的 `bodyText` / `titleText` 必須以純文字呈現，不能執行標記。
+
+    改寫時把原本 confirm() 的純文字訊息搬進了 modal，而 modal 的 `title` /
+    `body` 是走 innerHTML 的 —— 帶使用者內容的呼叫點（觀眾訊息、上傳檔名、
+    關鍵字）因此一度可以被注入標記。安全路徑是 textContent 版的欄位，這條測
+    的就是它真的沒有解析 HTML。
+    """
+    payload = '<img src=x onerror="window.__xss=1">刪除這個？'
+    result = admin_page.evaluate(
+        """async (payload) => {
+            window.__xss = 0;
+            const p = window.HudConfirm.open({ title: "測試", bodyText: payload });
+            await new Promise((r) => requestAnimationFrame(r));
+            const body = document.querySelector("[data-modal-body]");
+            const out = {
+                text: body ? body.textContent : null,
+                injectedNodes: body ? body.querySelectorAll("img").length : -1,
+                xssFlag: window.__xss,
+            };
+            document.querySelector(".admin-hud-modal__btn--cancel")?.click();
+            await p;
+            return out;
+        }""",
+        payload,
+    )
+
+    assert result["text"] == payload, "bodyText 應該原樣顯示成文字"
+    assert result["injectedNodes"] == 0, "bodyText 不該被解析成 DOM 元素"
+    assert result["xssFlag"] == 0, "注入的 onerror 被執行了"
+
+
+def test_block_confirm_shows_message_text_verbatim(admin_page, live_url):
+    """live feed 的封鎖確認帶的是觀眾訊息內容 —— 必須原樣顯示，不能被解析。
+
+    這是整批改寫裡最危險的一個呼叫點：`display` 直接來自觀眾送出的文字。
+    """
+    payload = '<img src=x onerror="window.__xss=1">'
+    admin_page.evaluate("() => { window.__xss = 0; }")
+    shown = admin_page.evaluate(
+        """async (payload) => {
+            const p = window.HudConfirm.open({
+                title: "封鎖",
+                bodyText: (window.ServerI18n?.t?.("blockConfirm") || "{display}")
+                    .replace("{label}", "訊息")
+                    .replace("{display}", payload),
+            });
+            await new Promise((r) => requestAnimationFrame(r));
+            const body = document.querySelector("[data-modal-body]");
+            const out = { html: body.innerHTML, imgs: body.querySelectorAll("img").length };
+            document.querySelector(".admin-hud-modal__btn--cancel")?.click();
+            await p;
+            return out;
+        }""",
+        payload,
+    )
+
+    assert shown["imgs"] == 0, "觀眾訊息裡的標記被解析成元素了"
+    assert "&lt;img" in shown["html"], f"訊息應該被轉義後顯示，實際 HTML: {shown['html']}"
+    assert admin_page.evaluate("() => window.__xss") == 0
 
 
 # ─── Metrics API ───────────────────────────────────────────────────────────────

--- a/server/tests/test_browser_admin.py
+++ b/server/tests/test_browser_admin.py
@@ -391,14 +391,16 @@ def test_blacklist_remove_keyword_disappears(admin_page):
     admin_page.click("#addKeywordBtn")
     admin_page.wait_for_selector('[data-keyword="remove_via_browser"]', timeout=3000)
 
-    # 再移除（移除時有 confirm() 對話框，需自動接受）
+    # 再移除。移除確認以前是原生 confirm()（靠 page.on("dialog") 自動接受），
+    # 現在走 HUD modal —— 要實際按下面板上的確認鍵。
     responses = []
     admin_page.on(
         "response",
         lambda r: responses.append(r) if "/admin/blacklist/remove" in r.url else None,
     )
-    admin_page.on("dialog", lambda d: d.accept())
     admin_page.locator('[data-keyword="remove_via_browser"]').click()
+    admin_page.wait_for_selector(".admin-hud-modal__btn--confirm", state="visible", timeout=5000)
+    admin_page.locator(".admin-hud-modal__btn--confirm").click()
     admin_page.wait_for_timeout(800)
 
     remove_resp = [r for r in responses if "/admin/blacklist/remove" in r.url]

--- a/server/tests/test_browser_viewer.py
+++ b/server/tests/test_browser_viewer.py
@@ -482,16 +482,34 @@ def test_reconnected_toast_appears_and_disappears(viewer_page):
     was_offline = page.evaluate("() => !!document.querySelector('.admin-offline-banner')")
     assert was_offline, "Expected offline banner to appear after 3 consecutive poll failures"
 
+    # 重連 toast 只活大約 2 秒，所以不能「先等固定秒數、再去抓它」—— 那是在賭
+    # 取樣點正好落在它的存活窗口內，CI 稍慢或稍快都會落空（實測就是這樣紅的）。
+    # 改成在恢復連線「之前」先掛觀察器記下它曾經出現，再等它自己消失。
+    page.evaluate("""() => {
+            window.__toastSeen = 0;
+            window.__toastText = "";
+            const check = () => {
+                const el = document.querySelector(".viewer-reconnected-toast");
+                if (el) {
+                    window.__toastSeen++;
+                    window.__toastText = (el.textContent || "").trim();
+                }
+            };
+            new MutationObserver(check).observe(document.body, {
+                childList: true,
+                subtree: true,
+            });
+            check();
+        }""")
+
     state["fail"] = False
-    page.wait_for_timeout(2500)  # next successful tick flips to 'connected'
+    page.wait_for_function("() => window.__toastSeen > 0", timeout=15000)
+    assert page.evaluate("() => window.__toastText") in ("已重新連線", "Reconnected")
 
-    toast = page.locator(".viewer-reconnected-toast")
-    toast.wait_for(state="visible", timeout=5000)
-    assert toast.is_visible()
-    assert toast.text_content().strip() in ("已重新連線", "Reconnected")
-
-    # Should auto-clear ~2s later.
-    toast.wait_for(state="detached", timeout=5000)
+    # 出現之後應該會自己收掉。
+    page.wait_for_function(
+        "() => !document.querySelector('.viewer-reconnected-toast')", timeout=15000
+    )
     assert page.locator(".viewer-reconnected-toast").count() == 0
 
 


### PR DESCRIPTION
`admin-hud-modal.js` 從 2026-05-18 就存在，docstring 明寫它是要「replace the ad-hoc `confirm()` calls scattered through the admin modules」。十個模組採用了，**二十五個繼續用原生對話框**，而且有幾個是兩者並存——把 modal 包在 `window.HudConfirm ? await open(…) : confirm(…)` 裡，等於又把要被取代的東西放了回來。

原生 `confirm()` 會凍住整個分頁、完全無視 admin 的視覺語言，也表達不出這些動作需要的 title / subtitle / severity 層次——「Factory reset」和「刪除這個小工具?」跳出來長得一模一樣。

## 改動

**25 個模組、43 處**全部改走 modal，每處都給了 icon、severity，以及一句點明後果的 subtitle：

```js
const ok = await window.HudConfirm?.open({
  icon: "⊘",
  title: "撤銷 Fire Token",
  subtitle: "REVOKE · ALL EXTENSIONS STOP WORKING",
  severity: "danger",
  body: "所有 extension 會立即停止運作，直到你產生新的 Token 並重新設定它們。",
  confirmLabel: "撤銷",
});
if (!ok) return;
```

三處原本在非 async 的事件處理器裡，需要把 listener 本身改成 async：modqueue 的批次動作委派、poll-builder 的編輯器委派、command palette 的清空歷史項目。（`await` 出現在非 async 函式是語法錯誤，所以 `node --check` 就能把這類問題全部攔下來。）

## `?.` 是刻意的

呼叫端一律寫 `await window.HudConfirm?.open(…)`。optional chaining 就是 fail-safe：萬一腳本沒載入，整個表達式是 `undefined`（falsy），破壞性動作被當成取消。舊的三元式退回 `confirm()`，等於把「要刪掉全部嗎？」的答案從「不要」變成「換個對話框再問一次」——那是錯的預設。

## 防回歸

新增 `admin-no-native-confirm.test.js`，掃過所有 `admin*.js`，出現任何新的原生呼叫就紅。它會先剝掉註解與字串字面量（避免把訊息裡的 `confirm(` 當成呼叫），並且**自帶一個偵測器自檢**——否則哪天有人把 regex 改壞，主測試會「因為抓不到東西」而假綠。

`test_blacklist_remove_keyword_disappears` 原本用 `page.on("dialog", d.accept())` 接原生對話框，現在改成實際點 modal 的確認鍵——順帶證明面板真的渲染得出來、按得下去。

## 驗證

| | 結果 |
|---|---|
| Electron jest | **527 passed / 33 suites**（新增守門測試 2 條） |
| `test_browser_admin.py` + route smoke | **126 passed** |
| server 全套 | **1294 passed, 6 skipped** |
| 隔離 browser harness | **6 passed** |
| `node --check` 全部 `admin*.js` | 通過 |

route smoke 對 19 條路由的 console error 斷言為零，代表這 25 個模組改完後在瀏覽器裡載入都沒有 JS 錯誤。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced browser-native confirmation prompts across multiple administrative destructive actions with consistent HUD confirmation modals.
  * Destructive actions now use richer, structured dialog content (warnings, severity, labels) and only proceed after explicit confirmation.
  * Added support for “safe text” modal content to prevent markup from being executed.

* **Tests**
  * Updated browser tests to confirm via the HUD modal instead of native dialogs.
  * Added regression coverage ensuring cancel sends no destructive requests, confirmations execute correctly, and dynamic text is safely rendered without native dialog usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->