### PR TITLE
refactor(css): 移除 10 條無作用的 !important，順手修好手機版 KPI strip (#120)

### DIFF
--- a/server/static/css/style.css
+++ b/server/static/css/style.css
@@ -4203,13 +4203,20 @@ body[data-active-route]:not([data-active-route="dashboard"]) .admin-dash-summary
 
 /* Tablet (641-1023px) — 2-col KPI tile to avoid the tall stack of 4
    tiles you get going straight to single column. design v4 2026-05-18. */
+/* Both breakpoints match `.is-4col`'s specificity instead of reaching for
+   !important. The single-class form used to lose to `.admin-kpi-strip.is-4col`
+   (two classes) no matter the source order — tablet papered over it with
+   !important, mobile didn't, so phones rendered four KPI columns instead of
+   one. Same specificity + later in the file now wins on order alone. */
 @media (min-width: 641px) and (max-width: 1023px) {
-  .admin-kpi-strip {
-    grid-template-columns: repeat(2, 1fr) !important;
+  .admin-kpi-strip,
+  .admin-kpi-strip.is-4col {
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 @media (max-width: 640px) {
-  .admin-kpi-strip {
+  .admin-kpi-strip,
+  .admin-kpi-strip.is-4col {
     grid-template-columns: 1fr;
   }
 }
@@ -5776,9 +5783,9 @@ body.stream-mode .admin-hero .admin-summary-grid {
 
 /* sidebar sub-row indent */
 .admin-dash-nav-row--sub {
-  padding-left: 26px !important;
+  padding-left: 26px;
   opacity: 0.85;
-  font-size: 12px !important;
+  font-size: 12px;
 }
 
 .admin-ext-token-deeplink {
@@ -9970,7 +9977,7 @@ body[data-message-drawer-open="1"] .admin-msgd-overlay { pointer-events: auto; }
 /* ─── Audit Log (P1, 2026-04-27) ───────────────────────────────────── */
 .admin-audit-page { padding: 0; }
 .admin-audit-empty {
-  padding: 24px !important;
+  padding: 24px;
   text-align: center;
   color: var(--color-text-muted);
   font-size: 11px;
@@ -12014,14 +12021,21 @@ body[data-message-drawer-open="1"] .admin-msgd-overlay { pointer-events: auto; }
 /* Mobile bottom-sheet variant — design v4 brief 0518-1 mobile mockup */
 @media (max-width: 600px) {
   .admin-hud-modal__panel {
+    /* width / max-width keep !important: the panel carries an inline
+       `style="width:…px;max-width:calc(100% - 32px)"` from admin-hud-modal.js,
+       and nothing but !important outranks an inline declaration.
+       The rest do not — this block is the last `.admin-hud-modal__panel` rule
+       in the file, so it already wins on order against the base rule and the
+       earlier 600px block. Verified with a computed-style probe across
+       desktop / tablet / mobile. */
     width: 100% !important;
     max-width: 100% !important;
-    border-radius: var(--radius-xl) var(--radius-xl) 0 0 !important;
-    position: absolute !important;
-    bottom: 0 !important;
-    left: 0 !important;
-    right: 0 !important;
-    margin: 0 !important;
+    border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: 0;
   }
   .admin-sd-ann-row {
     grid-template-columns: 44px 80px 1fr 18px;

--- a/server/tests/test_browser_admin.py
+++ b/server/tests/test_browser_admin.py
@@ -894,6 +894,45 @@ def test_block_confirm_shows_message_text_verbatim(admin_page, live_url):
     assert admin_page.evaluate("() => window.__xss") == 0
 
 
+# ─── KPI strip 響應式欄數 ─────────────────────────────────────────────────────
+
+
+def test_kpi_strip_column_count_per_breakpoint(browser_session, live_url):
+    """KPI strip 在三個斷點分別是 4 / 2 / 1 欄。
+
+    回歸保護：`.admin-kpi-strip.is-4col` 是兩個類別，會蓋過 media query 裡的
+    單類別規則，跟原始碼順序無關。tablet 那條當初用 !important 繞過去了，
+    mobile 那條沒有 —— 於是手機上四個 KPI 擠成四欄。現在兩個斷點都用對等特異性
+    (`.admin-kpi-strip, .admin-kpi-strip.is-4col`)，不再依賴 !important。
+    """
+    expected = {1440: 4, 800: 2, 375: 1}
+    actual = {}
+    for width, _ in expected.items():
+        context = browser_session.new_context(viewport={"width": width, "height": 900})
+        page = context.new_page()
+        try:
+            page.goto(f"{live_url}/admin/")
+            page.wait_for_selector("#loginForm", timeout=8000)
+            page.fill("#password", "test")
+            page.locator("#loginForm button[type=submit]").click()
+            page.wait_for_selector("#logoutButton", timeout=15000)
+            page.evaluate(
+                '() => { try { localStorage.setItem("danmu.onboarding.done", "1"); }'
+                " catch (_) {} }"
+            )
+            page.evaluate('() => { window.location.hash = "#/live"; }')
+            page.wait_for_selector(".admin-kpi-strip", state="visible", timeout=8000)
+            actual[width] = page.evaluate("""() => {
+                    const el = document.querySelector(".admin-kpi-strip");
+                    return getComputedStyle(el).gridTemplateColumns.split(" ").length;
+                }""")
+        finally:
+            page.close()
+            context.close()
+
+    assert actual == expected, f"KPI 欄數不符：{actual}（預期 {expected}）"
+
+
 # ─── Metrics API ───────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## 先把數字弄清楚

七個手寫樣式表裡實際有 **78 條** `!important` 宣告。先前記載的 89 和我一開始 grep 到的 103，都把「註解裡提到這個關鍵字」和 tailwind 生成檔算進去了。

分成三類：

| 類別 | 數量 | 處置 |
|---|---:|---|
| `prefers-reduced-motion` kill-switch | 27 | **不動** — 設計上就必須壓過一切 |
| `[hidden]` / data-attribute 狀態切換 | 19 | 本輪未動 |
| 其他 | 32 | 本輪目標 |

## 移除 10 條，每條都經過驗證

驗證方式是 computed-style probe：22 個 surface（desktop / tablet / mobile × viewer / overlay / 8 條 admin 路由 / HUD modal），改動前後逐值比對。

- **6 條**在 `<=600px` 的 modal bottom-sheet 區塊。`width` / `max-width` **保留**——panel 帶著 `admin-hud-modal.js` 給的 inline `style="width:…"`，只有 `!important` 壓得過 inline 宣告。其餘六條沒有這種競爭者，而且該區塊本來就是檔案裡最後一個 `.admin-hud-modal__panel` 規則。
- **2 條**在 `.admin-dash-nav-row--sub`（padding-left、font-size）
- **1 條**在 `.admin-audit-empty`（padding）
- **1 條**在 tablet KPI strip，改用對等特異性取代（見下）

## 保留的，把理由寫下來

不是「看起來危險所以留著」，而是查清楚為什麼必要並寫進註解：

- `.admin-kpi-tile-bars > span:last-child` — 要覆蓋 `admin-dashboard.js` 逐條設的 inline opacity
- `.admin-aud-row.is-selected` — 要壓過特異性更高的 `:hover` 規則
- `.admin-msgd-drawer` 與 8155 的 modal 區塊 — 它們的 media query 出現在基礎規則**之前**，同特異性下會輸給後面的規則

## Probe 順手抓到一個真 bug

`.admin-kpi-strip.is-4col` 是兩個類別，會壓過兩個 KPI media query 裡的單類別規則，**與原始碼順序無關**。tablet 當初用 `!important` 繞過去了，mobile 沒有——所以**手機上四個 KPI 擠成四欄**，而不是設計的一欄。

正解不是給 mobile 也補一個 `!important`，而是讓兩個斷點都用 `.admin-kpi-strip, .admin-kpi-strip.is-4col` 對等特異性，靠順序取勝。**修好 mobile 的同時也把 tablet 那條 `!important` 拿掉了。**

實測 375px：4 欄 / 191px 高 → **1 欄 / 546px 高**。

`test_kpi_strip_column_count_per_breakpoint` 釘住三個斷點的 4 / 2 / 1。Mutation 驗證過：把 mobile 選擇器改回單類別，它會報 `{1440: 4, 800: 2, 375: 4}`。

## 沒做的部分

`danmu-desktop/styles.css` 那 8 條要在 Electron runtime 裡才驗得了，是另一套 harness，本 PR 不碰。剩下的 19 條狀態切換與其餘「其他」類也留待後續。

78 → **68**。

## 驗證

| | 結果 |
|---|---|
| computed-style probe | 22 surfaces / 73 快照，除 KPI 修復外零差異 |
| `test_browser_admin.py` + route smoke | **132 passed** |
| server 全套 | **1294 passed, 6 skipped** |
| 隔離 browser harness | **6 passed** |
| Electron jest | **527 passed** |
| `check-css-tokens` | 通過 |
| tailwind.css | 無需重生 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed responsive admin dashboard KPI layouts to display four columns on large screens, two on tablets, and one on mobile.
  * Improved mobile modal positioning and sidebar sub-navigation styling.
  * Corrected audit page empty-state spacing.

* **Tests**
  * Added browser coverage to verify KPI column behavior across desktop, tablet, and mobile screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->