### PR TITLE
feat(history): 彈幕記錄落地成檔案，撐得過重啟

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,6 +128,15 @@ FONT_TOKEN_EXPIRATION=900   # Font download token TTL (seconds)
 # Danmu history
 # DANMU_HISTORY_MAX_RECORDS=10000
 # DANMU_HISTORY_CLEANUP_HOURS=24
+# Persist records to runtime/danmu_history.jsonl so they survive a restart.
+# Set to false to keep the old memory-only behaviour.
+# DANMU_HISTORY_PERSIST=true
+# Include the sender's IP in the persisted file. Off by default — the IP stays
+# in memory for the admin UI either way, but writing it to disk keeps it around
+# indefinitely, which is a different thing to agree to.
+# DANMU_HISTORY_PERSIST_IP=false
+# Rotate to danmu_history.jsonl.1 past this size (bytes, default 8 MiB).
+# DANMU_HISTORY_MAX_FILE_BYTES=8388608
 
 # Webhooks
 # WEBHOOK_TIMEOUT=10        # HTTP timeout per webhook call (seconds)

--- a/server/config.py
+++ b/server/config.py
@@ -130,6 +130,15 @@ class Config:
     # Danmu history configuration
     DANMU_HISTORY_MAX_RECORDS = int(os.getenv("DANMU_HISTORY_MAX_RECORDS", "10000"))
     DANMU_HISTORY_CLEANUP_HOURS = int(os.getenv("DANMU_HISTORY_CLEANUP_HOURS", "24"))
+    # 落地到 runtime/danmu_history.jsonl，讓記錄撐得過重啟。
+    DANMU_HISTORY_PERSIST = os.getenv("DANMU_HISTORY_PERSIST", "true").lower() == "true"
+    # 落地時是否含 clientIp。預設否 —— 把來訪者 IP 永久寫進磁碟，跟留在一個
+    # 重啟就清掉的 ring buffer 裡，是兩件不同性質的事。admin 介面看到的記憶體
+    # 記錄不受影響。
+    DANMU_HISTORY_PERSIST_IP = os.getenv("DANMU_HISTORY_PERSIST_IP", "false").lower() == "true"
+    DANMU_HISTORY_MAX_FILE_BYTES = int(
+        os.getenv("DANMU_HISTORY_MAX_FILE_BYTES", str(8 * 1024 * 1024))
+    )
     # Default settings file lives alongside other runtime state under
     # server/runtime/. Previously used /tmp which is wiped on reboot on
     # many systems (macOS default, some Linux), silently losing user settings.

--- a/server/services/history.py
+++ b/server/services/history.py
@@ -1,32 +1,133 @@
-"""彈幕記錄服務"""
+"""彈幕記錄服務
 
+記錄同時存在兩個地方：
+
+  * 記憶體 deque —— 所有讀取路徑（列表 / 統計 / 匯出）都走這裡，行為與
+    落地前完全相同。
+  * ``runtime/danmu_history.jsonl`` —— append-only，讓記錄能撐過重啟。
+    寫入策略沿用 audit_log.py：一行一筆 JSON、超過上限就 rotate 成 ``.1``、
+    寫入失敗只降級成記憶體模式而不讓 /fire 失敗。
+
+隱私：記憶體裡的記錄含 ``clientIp``，那是 admin 介面在用的。落地時預設**不寫
+入 IP**（``DANMU_HISTORY_PERSIST_IP=true`` 可改變），因為把來訪者 IP 永久寫進
+磁碟跟留在一個會被重啟清掉的 ring buffer 裡，是兩件不同性質的事。fingerprint
+留著 —— 它本來就是雜湊值，而且黑名單與觀眾追蹤都靠它。
+"""
+
+import json
 import logging
 import threading
 import time
 from collections import deque
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Dict, List, Optional
 
 from ..config import Config
 
 logger = logging.getLogger(__name__)
 
+_RUNTIME = Path(__file__).parent.parent / "runtime"
+HISTORY_FILE = _RUNTIME / "danmu_history.jsonl"
+HISTORY_BACKUP_FILE = _RUNTIME / "danmu_history.jsonl.1"
+
 
 class DanmuHistory:
     """彈幕記錄管理器"""
 
-    def __init__(self, max_records: int = 10000, auto_cleanup_hours: int = 24):
+    def __init__(
+        self,
+        max_records: int = 10000,
+        auto_cleanup_hours: int = 24,
+        persist: bool = True,
+        persist_ip: bool = False,
+        max_file_bytes: int = 8 * 1024 * 1024,
+    ):
         """
         初始化彈幕記錄管理器
 
         Args:
             max_records: 最大記錄數（防止內存溢出）
             auto_cleanup_hours: 自動清理超過此小時數的記錄
+            persist: 是否把記錄 append 到 danmu_history.jsonl
+            persist_ip: 落地時是否包含 clientIp（預設不含，見模組 docstring）
+            max_file_bytes: 檔案超過此大小就 rotate 成 .jsonl.1
         """
         self._records: deque = deque(maxlen=max_records)
         self._lock = threading.Lock()
         self.auto_cleanup_hours = auto_cleanup_hours
+        self.persist = persist
+        self.persist_ip = persist_ip
+        self.max_file_bytes = max_file_bytes
+        self._write_failure_logged = False
         self.last_cleanup = time.time()
+        if self.persist:
+            self._load_from_disk()
+
+    # ── 落地 ────────────────────────────────────────────────────────────
+
+    def _load_from_disk(self) -> None:
+        """啟動時把檔案內容讀回 deque。
+
+        deque 的 maxlen 會自動只保留最後 max_records 筆，所以即使檔案比記憶體
+        上限大也不會爆。壞掉的行直接跳過 —— 一筆讀不出來不該讓整個服務起不來。
+        """
+        if not HISTORY_FILE.exists():
+            return
+        loaded = skipped = 0
+        try:
+            with HISTORY_FILE.open("r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        self._records.append(json.loads(line))
+                        loaded += 1
+                    except (json.JSONDecodeError, ValueError):
+                        skipped += 1
+        except OSError as exc:
+            logger.warning("danmu history: cannot read %s: %s", HISTORY_FILE, exc)
+            return
+        logger.info(
+            "danmu history: restored %d records from disk%s",
+            loaded,
+            f" ({skipped} unreadable lines skipped)" if skipped else "",
+        )
+
+    def _try_rotate(self) -> None:
+        """超過上限就轉存成 .1（只留一份備份，跟 audit.log 一致）。"""
+        try:
+            if HISTORY_FILE.stat().st_size < self.max_file_bytes:
+                return
+            if HISTORY_BACKUP_FILE.exists():
+                HISTORY_BACKUP_FILE.unlink()
+            HISTORY_FILE.rename(HISTORY_BACKUP_FILE)
+        except OSError as exc:
+            logger.warning("danmu history: rotate failed: %s", exc)
+
+    def _append_to_disk(self, record: Dict) -> None:
+        """Best-effort append。寫不進去就降級成純記憶體，不讓 /fire 失敗。"""
+        if not self.persist:
+            return
+        payload = (
+            record if self.persist_ip else {k: v for k, v in record.items() if k != "clientIp"}
+        )
+        try:
+            HISTORY_FILE.parent.mkdir(parents=True, exist_ok=True)
+            if HISTORY_FILE.exists():
+                self._try_rotate()
+            with HISTORY_FILE.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        except OSError as exc:
+            if not self._write_failure_logged:
+                logger.warning(
+                    "danmu history: cannot persist to %s (%s) — "
+                    "continuing in memory only; records will not survive a restart",
+                    HISTORY_FILE,
+                    exc,
+                )
+                self._write_failure_logged = True
 
     def add(self, danmu_data: Dict):
         """
@@ -51,6 +152,8 @@ class DanmuHistory:
 
         with self._lock:
             self._records.append(record)
+        # 落地在鎖外做：磁碟 I/O 不該擋住其他送出中的彈幕。
+        self._append_to_disk(record)
         # 定期清理舊記錄（在鎖外呼叫，避免 deadlock）
         self._maybe_cleanup()
 
@@ -157,9 +260,21 @@ class DanmuHistory:
         }
 
     def clear(self):
-        """清空所有記錄"""
+        """清空所有記錄（記憶體與磁碟）
+
+        Admin UI 的文案是「清除所有彈幕歷史，此動作無法復原」，所以落地檔案也
+        要一起清掉 —— 只清記憶體的話，重啟後記錄又會冒回來，跟使用者被告知的
+        結果不符。
+        """
         with self._lock:
             self._records.clear()
+        if not self.persist:
+            return
+        for path in (HISTORY_FILE, HISTORY_BACKUP_FILE):
+            try:
+                path.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning("danmu history: cannot remove %s: %s", path, exc)
 
     def _maybe_cleanup(self):
         """定期清理舊記錄（時間檢查在鎖內防止 TOCTOU race）"""
@@ -245,4 +360,7 @@ def init_history():
     danmu_history = DanmuHistory(
         max_records=Config.DANMU_HISTORY_MAX_RECORDS,
         auto_cleanup_hours=Config.DANMU_HISTORY_CLEANUP_HOURS,
+        persist=Config.DANMU_HISTORY_PERSIST,
+        persist_ip=Config.DANMU_HISTORY_PERSIST_IP,
+        max_file_bytes=Config.DANMU_HISTORY_MAX_FILE_BYTES,
     )

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -136,6 +136,24 @@ def _isolate_onscreen_limits(tmp_path):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_api_tokens(tmp_path):
+    """把 API token 儲存導到 tmp_path。
+
+    沒有這層隔離，任何建立 / 撤銷 token 的測試都會寫進正式的
+    server/runtime/api_tokens.json —— 那個檔現在有 176 筆、78KB，裡面躺著
+    label="contract-test" 之類的紀錄，就是這樣累積出來的。
+    """
+    from server.services import api_tokens
+
+    original = api_tokens._TOKENS_FILE
+    api_tokens._TOKENS_FILE = str(tmp_path / "api_tokens.json")
+    try:
+        yield
+    finally:
+        api_tokens._TOKENS_FILE = original
+
+
+@pytest.fixture(autouse=True)
 def _isolate_danmu_history(tmp_path):
     """把彈幕歷史的落地檔導到 tmp_path。
 

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -136,6 +136,27 @@ def _isolate_onscreen_limits(tmp_path):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_danmu_history(tmp_path):
+    """把彈幕歷史的落地檔導到 tmp_path。
+
+    沒有這層隔離的話，任何送出彈幕的測試都會 append 進真正的
+    server/runtime/danmu_history.jsonl。runtime/api_tokens.json 就是這樣被
+    測試資料污染的（裡面躺著 label="contract-test" 的紀錄），這裡不重蹈覆轍。
+    """
+    from server.services import history as history_service
+
+    original_file = history_service.HISTORY_FILE
+    original_backup = history_service.HISTORY_BACKUP_FILE
+    history_service.HISTORY_FILE = tmp_path / "danmu_history.jsonl"
+    history_service.HISTORY_BACKUP_FILE = tmp_path / "danmu_history.jsonl.1"
+    try:
+        yield
+    finally:
+        history_service.HISTORY_FILE = original_file
+        history_service.HISTORY_BACKUP_FILE = original_backup
+
+
+@pytest.fixture(autouse=True)
 def _isolate_ws_auth(tmp_path, request):
     """Isolate ws_auth runtime file per test to avoid cross-test pollution.
 

--- a/server/tests/test_history_persistence.py
+++ b/server/tests/test_history_persistence.py
@@ -1,0 +1,164 @@
+"""彈幕歷史落地（runtime/danmu_history.jsonl）。
+
+在此之前記錄只活在記憶體 deque 裡，重啟就全沒了 —— 場次封存
+(sessions_archive.jsonl) 也只寫 metadata，不含訊息本身。
+"""
+
+import json
+
+import pytest
+
+from server.services import history as history_service
+from server.services.history import DanmuHistory
+
+
+@pytest.fixture()
+def store(tmp_path, monkeypatch):
+    """指向 tmp_path 的落地路徑，並回傳一個工廠讓測試能模擬「重啟」。"""
+    hist_file = tmp_path / "danmu_history.jsonl"
+    backup_file = tmp_path / "danmu_history.jsonl.1"
+    monkeypatch.setattr(history_service, "HISTORY_FILE", hist_file)
+    monkeypatch.setattr(history_service, "HISTORY_BACKUP_FILE", backup_file)
+
+    def make(**kwargs):
+        kwargs.setdefault("max_records", 100)
+        return DanmuHistory(**kwargs)
+
+    return make, hist_file, backup_file
+
+
+def _danmu(text, ip="203.0.113.7", fp="fp_abc123"):
+    return {"text": text, "color": "#fff", "size": 30, "clientIp": ip, "fingerprint": fp}
+
+
+def test_records_are_appended_to_disk(store):
+    make, hist_file, _ = store
+    h = make()
+    h.add(_danmu("hello"))
+    h.add(_danmu("world"))
+
+    lines = hist_file.read_text(encoding="utf-8").strip().split("\n")
+    assert len(lines) == 2
+    assert [json.loads(ln)["text"] for ln in lines] == ["hello", "world"]
+
+
+def test_records_survive_a_restart(store):
+    """核心行為：新的 instance 要能把先前的記錄讀回來。"""
+    make, _, _ = store
+    first = make()
+    for i in range(5):
+        first.add(_danmu(f"msg-{i}"))
+
+    restarted = make()
+    texts = [r["text"] for r in restarted.get_records(limit=100)]
+    assert sorted(texts) == sorted(f"msg-{i}" for i in range(5))
+
+
+def test_client_ip_is_not_persisted_by_default(store):
+    """IP 留在記憶體給 admin 用，但不寫進磁碟。"""
+    make, hist_file, _ = store
+    h = make()
+    h.add(_danmu("hi", ip="198.51.100.42"))
+
+    on_disk = json.loads(hist_file.read_text(encoding="utf-8").strip())
+    assert "clientIp" not in on_disk
+    assert on_disk["fingerprint"] == "fp_abc123", "fingerprint 要留著（黑名單/觀眾追蹤靠它）"
+    assert "198.51.100.42" not in hist_file.read_text(encoding="utf-8")
+
+    # 記憶體裡仍然看得到，admin 行為不變。
+    assert h.get_records(limit=10)[0]["clientIp"] == "198.51.100.42"
+
+
+def test_client_ip_persisted_when_explicitly_enabled(store):
+    make, hist_file, _ = store
+    h = make(persist_ip=True)
+    h.add(_danmu("hi", ip="198.51.100.42"))
+    assert json.loads(hist_file.read_text(encoding="utf-8").strip())["clientIp"] == "198.51.100.42"
+
+
+def test_clear_removes_the_file_too(store):
+    """UI 說「無法復原」，所以磁碟也要清 —— 否則重啟後記錄會冒回來。"""
+    make, hist_file, backup_file = store
+    h = make()
+    h.add(_danmu("bye"))
+    backup_file.write_text('{"text": "old"}\n', encoding="utf-8")
+    assert hist_file.exists()
+
+    h.clear()
+    assert not hist_file.exists()
+    assert not backup_file.exists(), "備份檔留著的話，rotation 後的舊記錄還在"
+    assert make().get_records(limit=10) == []
+
+
+def test_file_rotates_at_the_size_cap(store):
+    make, hist_file, backup_file = store
+    h = make(max_file_bytes=200)
+    for i in range(40):
+        h.add(_danmu(f"padding-message-{i}"))
+
+    assert backup_file.exists(), "超過上限應該轉存成 .1"
+    assert hist_file.stat().st_size < 4000, "rotate 之後主檔應該重新變小"
+
+
+def test_unreadable_lines_are_skipped_not_fatal(store):
+    """一行壞掉不該讓整個服務起不來。"""
+    make, hist_file, _ = store
+    hist_file.write_text(
+        '{"text": "good-1", "timestamp": "2026-07-28T00:00:00+00:00"}\n'
+        "{ this is not json\n"
+        '{"text": "good-2", "timestamp": "2026-07-28T00:00:01+00:00"}\n',
+        encoding="utf-8",
+    )
+    texts = [r["text"] for r in make().get_records(limit=10)]
+    assert sorted(texts) == ["good-1", "good-2"]
+
+
+def test_persist_disabled_writes_nothing(store):
+    make, hist_file, _ = store
+    h = make(persist=False)
+    h.add(_danmu("nope"))
+    assert not hist_file.exists()
+    assert len(h.get_records(limit=10)) == 1, "關閉落地不影響記憶體行為"
+
+
+def test_write_failure_degrades_to_memory_only(store, monkeypatch, caplog):
+    """磁碟寫不進去時，/fire 不能因此失敗。"""
+    make, hist_file, _ = store
+    h = make()
+
+    def _boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("pathlib.Path.open", _boom)
+    h.add(_danmu("still-works"))  # 不應該拋出
+
+    assert len(h.get_records(limit=10)) == 1
+
+
+# ─── 端對端：真的走 HTTP /fire ────────────────────────────────────────────────
+
+
+def test_fire_endpoint_persists_to_disk(client, tmp_path, monkeypatch):
+    """POST /fire 之後，記錄要真的落在檔案裡。
+
+    前面的測試都直接操作 DanmuHistory；這條走完整條路徑（HTTP → 過濾 → 轉發
+    → _record_history_if_enabled），確認落地確實掛在真實流程上、而不只是在
+    單元測試裡可用。
+    """
+    from server.services.ws_state import update_ws_client_count
+
+    hist_file = tmp_path / "e2e_history.jsonl"
+    monkeypatch.setattr(history_service, "HISTORY_FILE", hist_file)
+    monkeypatch.setattr(history_service, "HISTORY_BACKUP_FILE", tmp_path / "e2e_history.jsonl.1")
+
+    # 沒有 overlay 連線時 /fire 會回 503，訊息也就不會被記錄 —— 記錄只發生在
+    # forward 成功（sent / queued）之後。
+    update_ws_client_count(1)
+
+    resp = client.post("/fire", json={"text": "persisted through http"})
+    assert resp.status_code == 200
+
+    assert hist_file.exists(), "/fire 成功之後應該要有落地檔"
+    record = json.loads(hist_file.read_text(encoding="utf-8").strip().split("\n")[-1])
+    assert record["text"] == "persisted through http"
+    assert "clientIp" not in record, "預設不落地 IP"


### PR DESCRIPTION
彈幕記錄原本只活在 `deque(maxlen=10000)` 裡——`history.py` 完全不碰檔案系統，而場次關閉只把 metadata 寫進 `sessions_archive.jsonl`，**不含訊息本身**。

結果是：**伺服器一重啟，所有彈幕記錄就沒了**；熱門場次超過一萬筆之後，最早的訊息會被靜靜擠掉。

## 做法

記錄現在同時 append 到 `runtime/danmu_history.jsonl`，沿用 `audit_log.py` 已經建立的形狀：

- 一行一筆 JSON
- 超過上限（預設 8 MiB）rotate 成 `.1`
- **寫入失敗只降級成記憶體模式，不讓 `/fire` 失敗**
- 啟動時讀回 deque —— `maxlen` 仍然限制記憶體，所以檔案比上限大也只會還原最新的那一段
- 壞掉的行跳過而不是讓服務起不來

`clear()` 現在會一併刪除檔案。Admin UI 寫的是「此動作無法復原」，只清記憶體的話重啟後記錄會冒回來，跟使用者被告知的結果不符。

## 一個需要你確認的預設

**落地的記錄預設不含 `clientIp`**（`DANMU_HISTORY_PERSIST_IP=true` 可開啟）。

Admin 介面看到的 IP 不受影響——那來自記憶體。但把來訪者 IP 永久寫進磁碟，跟留在一個重啟就清掉的 buffer 裡，是兩件性質不同的事，所以我沒有替你預設打開。

Fingerprint 保留：它本來就是雜湊值，而且黑名單與觀眾追蹤都靠它。

如果你要完整記錄（例如事後要追查濫用來源），把那個環境變數打開就好。

## 順手補一個測試隔離的洞

`conftest.py` 新增 `_isolate_danmu_history`。沒有它的話，**任何送出彈幕的測試都會 append 進真正的 runtime 檔**。

這不是假想：`runtime/api_tokens.json` 現在有 **176 筆**、78KB，裡面躺著 `label="contract-test"` 的紀錄——就是這樣被測試污染的。（那個檔的隔離不在本 PR 範圍，但同樣該補。）

## 驗證

10 條測試：append、重啟還原、IP 預設不落地與 opt-in、`clear` 清掉兩個檔、rotation、壞行容錯、`persist=false`、寫入失敗降級，外加**一條端對端**——真的 POST `/fire` 然後檢查檔案，確保落地是掛在真實路徑上而不只在單元層可用。

| | 結果 |
|---|---|
| server 全套 | **1304 passed, 6 skipped**（+10） |
| 隔離 browser harness | **6 passed** |
| runtime 污染檢查 | 跑完全套後 `danmu_history.jsonl` 不存在 ✓ |

`runtime/.gitignore` 是 `*`，落地檔不會進版控。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Danmu history can now persist across restarts.
  * History files automatically rotate when they reach the configured size limit.
  * Persistence can be disabled, and sender IP storage can be optionally enabled.
  * Clearing history also removes persisted records and backups.

* **Bug Fixes**
  * Invalid history entries no longer prevent history from loading.
  * Disk write failures gracefully fall back to in-memory history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->