### PR TITLE
feat(moderation): 讓時限封禁真的擋得住人

### DIFF
--- a/danmu-desktop/tests/admin-ban-duration.test.js
+++ b/danmu-desktop/tests/admin-ban-duration.test.js
@@ -1,0 +1,54 @@
+const { test, expect } = require("@jest/globals");
+const fs = require("fs");
+const path = require("path");
+
+// 封禁時長的標籤直接取自 chip 上的文字，不從秒數反推。
+//
+// 反推過一次就出過錯：`seconds >= 604800` 那條除以 604800，於是 7 天算成
+// 「1 天」，跟 24 小時選項的提示長得一模一樣 —— 管理員按了 7 天，畫面告訴他
+// 封了 1 天。這裡把「不要再引入這種推算」釘住。
+
+const SRC = fs.readFileSync(
+  path.join(__dirname, "..", "..", "server", "static", "js", "admin-message-drawer.js"),
+  "utf8"
+);
+
+test("duration chips carry both the seconds and the label", () => {
+  // 三個時長 + 永久，值必須對得上秒數。
+  const expected = [
+    ['data-ban-duration="3600"', "1 小時"],
+    ['data-ban-duration="86400"', "24 小時"],
+    ['data-ban-duration="604800"', "7 天"],
+    ['data-ban-duration="0"', "永久"],
+  ];
+  for (const [attr, label] of expected) {
+    const row = SRC.split("\n").find((l) => l.includes(attr));
+    // jest 的 expect 不吃第二個「訊息」參數（那是 chai 的寫法），所以自己丟。
+    if (!row) throw new Error(`找不到帶 ${attr} 的 chip`);
+    expect(row).toContain(label);
+  }
+});
+
+test("chips are selectable, not disabled", () => {
+  // 只看模板裡的 chip 本身 —— data-ban-duration 也出現在 closest() 選擇器裡。
+  const chipLines = SRC.split("\n").filter(
+    (l) => l.includes("data-ban-duration=") && l.includes("admin-bancfm-dchip")
+  );
+  expect(chipLines.length).toBe(4);
+  for (const line of chipLines) {
+    expect(line).not.toContain("is-disabled");
+    expect(line).toContain('role="button"');
+  }
+});
+
+test("no seconds-to-label arithmetic is reintroduced", () => {
+  // 604800 只該以「chip 的值」出現，不該出現在除法裡。
+  expect(SRC).not.toMatch(/\/\s*604800/);
+  expect(SRC).not.toContain("_durationLabel");
+});
+
+test("timed bans go to /admin/modbans, permanent to /admin/live/block", () => {
+  expect(SRC).toContain("/admin/modbans");
+  expect(SRC).toContain("/admin/live/block");
+  expect(SRC).toContain("duration_s");
+});

--- a/server/routes/api.py
+++ b/server/routes/api.py
@@ -7,7 +7,7 @@ from werkzeug.exceptions import HTTPException
 from .. import state
 from ..services import fingerprint_tracker
 from ..services import history as history_service
-from ..services import messaging
+from ..services import messaging, moderation_bans
 from ..services import themes as theme_svc
 from ..services.blacklist import contains_keyword
 from ..services.effects import load_all as load_all_effects
@@ -261,6 +261,17 @@ def fire():
 
         # Rate-limit chain. Aborts 429 internally; flask converts to response.
         enforce_fire_rate_limits(fingerprint, admin_client)
+
+        # Moderation bans — admin-issued, optionally time-bound. Checked before
+        # the filter engine because a banned sender's message should never reach
+        # the overlay regardless of content. moderation_bans keeps its own state
+        # map, so this is a dict lookup rather than a scan.
+        if fingerprint and moderation_bans.is_banned("fingerprint", fingerprint):
+            fingerprint_tracker.record(fingerprint, client_ip, user_agent, blocked=True)
+            return _json_response({"error": "You are currently banned"}, 403)
+        if client_ip and moderation_bans.is_banned("ip", client_ip):
+            fingerprint_tracker.record(fingerprint, client_ip, user_agent, blocked=True)
+            return _json_response({"error": "You are currently banned"}, 403)
 
         # Filter engine check (replaces simple blacklist check)
         filter_result = filter_engine.check(text_content, fingerprint)

--- a/server/services/moderation_bans.py
+++ b/server/services/moderation_bans.py
@@ -16,24 +16,86 @@ audit_log entry with shape:
       "reason":      "<short>"
     }
 
-`list_active(now=None)` reads the audit ring + walks targets in
-reverse-chrono order; the most recent event per (target_kind, target)
-determines current state. No background reaper thread — clients call
-`list_active()` lazily; expired entries are surfaced with state="expired"
-so the UI can show "已過期 · auto-unban" and the next admin action will
-auto-emit a `ban_expired` audit event for the notification feed.
+State lives in ``runtime/moderation_bans.json`` (one row per target),
+mirrored by an in-memory dict. audit_log still records every action for the
+audit trail, but it can no longer be the source of truth: its ring holds the
+newest 500 events *across all sources*, so a few hundred logins were enough to
+push a ban out of the window and silently un-ban someone. Measured before this
+change — issue a ban, append 520 unrelated events, and ``is_banned()`` flips
+back to False. A ban's lifetime has to depend on the duration the admin chose,
+not on how much else happened to be logged afterwards.
+
+No background reaper thread — expiry is evaluated on read, and expired rows are
+surfaced with status="expired" so the UI can show "已過期 · auto-unban".
 """
 
 from __future__ import annotations
 
+import json
+import logging
+import threading
 import time as _time
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from . import audit_log
 
+logger = logging.getLogger(__name__)
+
+_STATE_FILE = Path(__file__).parent.parent / "runtime" / "moderation_bans.json"
+_lock = threading.RLock()
+_state: Optional[Dict[str, Dict[str, Any]]] = None  # "kind\x00target" -> row
+
 _VALID_KINDS = {"fingerprint", "ip", "nick"}
 _VALID_LABELS = {"ban", "mute"}
 _MAX_REASON = 200
+
+
+def _key(target_kind: str, target: str) -> str:
+    return f"{target_kind}\x00{target}"
+
+
+def _load_state() -> Dict[str, Dict[str, Any]]:
+    """Read the ban rows from disk once, then keep them in memory."""
+    global _state
+    if _state is not None:
+        return _state
+    with _lock:
+        if _state is not None:
+            return _state
+        loaded: Dict[str, Dict[str, Any]] = {}
+        try:
+            if _STATE_FILE.exists():
+                raw = json.loads(_STATE_FILE.read_text(encoding="utf-8"))
+                if isinstance(raw, dict):
+                    for k, row in raw.items():
+                        # 只收形狀對的列 —— 壞掉一行不該讓封禁狀態整個讀不出來。
+                        if isinstance(row, dict) and row.get("target_kind") and row.get("target"):
+                            loaded[k] = row
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            logger.warning("moderation_bans: cannot read %s: %s", _STATE_FILE, exc)
+        _state = loaded
+        return _state
+
+
+def _save_state() -> None:
+    """Best-effort persist. Failures keep the in-memory view authoritative."""
+    if _state is None:
+        return
+    try:
+        _STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = _STATE_FILE.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(_state, ensure_ascii=False, indent=1), encoding="utf-8")
+        tmp.replace(_STATE_FILE)
+    except OSError as exc:
+        logger.warning("moderation_bans: cannot persist %s: %s", _STATE_FILE, exc)
+
+
+def reset_for_tests() -> None:
+    """Drop the cached state so a test can start from a clean slate."""
+    global _state
+    with _lock:
+        _state = None
 
 
 def _validate_target_kind(target_kind: str) -> None:
@@ -71,6 +133,15 @@ def add_ban(
         "reason": (reason or "").strip()[:_MAX_REASON],
     }
     audit_log.append("moderation", kind, actor=actor, meta=meta)
+    with _lock:
+        state = _load_state()
+        state[_key(target_kind, meta["target"])] = {
+            **meta,
+            "kind": kind,
+            "actor": actor,
+            "created_at": now,
+        }
+        _save_state()
     return meta
 
 
@@ -94,6 +165,10 @@ def remove_ban(
         "reason": (reason or "").strip()[:_MAX_REASON],
     }
     audit_log.append("moderation", "unban", actor=actor, meta=meta)
+    with _lock:
+        state = _load_state()
+        state.pop(_key(target_kind, meta["target"]), None)
+        _save_state()
     return meta
 
 
@@ -139,17 +214,15 @@ def list_active(now: Optional[float] = None) -> List[Dict[str, Any]]:
     """
     if now is None:
         now = _time.time()
-    # Pull all moderation events from the audit ring.
-    events = audit_log.recent(limit=500, source="moderation")
-    latest = _latest_per_target(events)
+    with _lock:
+        rows_in = list(_load_state().values())
     rows: List[Dict[str, Any]] = []
-    for (kind_, target), ev in latest.items():
-        action = ev.get("kind") or ""
-        meta = ev.get("meta") or {}
-        if action == "unban":
-            continue
+    for meta in rows_in:
+        action = meta.get("kind") or "ban"
         if action not in ("ban", "mute"):
             continue
+        kind_ = meta.get("target_kind")
+        target = meta.get("target")
         expires_at = meta.get("expires_at")
         duration_s = int(meta.get("duration_s") or 0)
         if not expires_at or duration_s <= 0:
@@ -171,8 +244,8 @@ def list_active(now: Optional[float] = None) -> List[Dict[str, Any]]:
                 "duration_s": duration_s,
                 "expires_at": expires_at,
                 "remaining_s": remaining,
-                "actor": ev.get("actor") or "admin",
-                "created_at": ev.get("ts"),
+                "actor": meta.get("actor") or "admin",
+                "created_at": meta.get("created_at"),
             }
         )
 
@@ -188,21 +261,22 @@ def list_active(now: Optional[float] = None) -> List[Dict[str, Any]]:
 
 
 def is_banned(target_kind: str, target: str, now: Optional[float] = None) -> bool:
-    """Lazy check used by the filter pipeline.
+    """Hot-path check — called for every incoming danmu.
 
-    Returns True iff the most recent moderation event for (target_kind, target)
-    is `ban`/`mute` AND its expires_at is None or in the future.
+    Reads the in-memory ban map, so cost is a dict lookup rather than a walk
+    over the audit ring (which also could not answer correctly once the ban
+    aged out of the 500-event window).
     """
+    if not target:
+        return False
     if now is None:
         now = _time.time()
-    events = audit_log.recent(limit=500, source="moderation")
-    latest = _latest_per_target(events)
-    ev = latest.get((target_kind, target))
-    if not ev or ev.get("kind") not in ("ban", "mute"):
+    with _lock:
+        row = _load_state().get(_key(target_kind, target))
+    if not row or row.get("kind") not in ("ban", "mute"):
         return False
-    meta = ev.get("meta") or {}
-    expires_at = meta.get("expires_at")
-    duration_s = int(meta.get("duration_s") or 0)
+    expires_at = row.get("expires_at")
+    duration_s = int(row.get("duration_s") or 0)
     if not expires_at or duration_s <= 0:
         return True  # permanent
     return expires_at > now

--- a/server/static/js/admin-broadcast.js
+++ b/server/static/js/admin-broadcast.js
@@ -448,7 +448,9 @@
     try {
       const r = await window.csrfFetch("/admin/overlay/clear", { method: "POST" });
       if (r.ok) window.showToast && showToast("已清空 Desktop", true);
-      else window.showToast && showToast("清空失敗 · 後端尚未實作此端點", false);
+      // 這個端點是有的（routes/admin/overlay.py），訊息以前寫「後端尚未實作」
+      // 是留下來沒更新的舊文案 —— 真的失敗時那會把人指向錯的方向。
+      else window.showToast && showToast(`清空失敗（HTTP ${r.status}）`, false);
     } catch (_) {
       window.showToast && showToast("清空失敗", false);
     }

--- a/server/static/js/admin-message-drawer.js
+++ b/server/static/js/admin-message-drawer.js
@@ -277,17 +277,41 @@
 
   // ── ban via existing /admin/live/block ──────────────────────────
 
-  async function _banFingerprint(reason) {
+  function _durationLabel(seconds) {
+    if (seconds >= 604800) return `${Math.round(seconds / 604800)} 天`;
+    if (seconds >= 86400) return `${Math.round(seconds / 86400)} 天`;
+    if (seconds >= 3600) return `${Math.round(seconds / 3600)} 小時`;
+    return `${seconds} 秒`;
+  }
+
+  async function _banFingerprint(reason, durationS) {
     const fp = _state.entry && _state.entry.data && _state.entry.data.fingerprint;
     if (!fp) return;
+    const seconds = parseInt(durationS || 0, 10) || 0;
     try {
-      const r = await window.csrfFetch("/admin/live/block", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ type: "fingerprint", value: fp, reason: reason || "" }),
-      });
+      // 永久封禁沿用 /admin/live/block（黑名單，訊息會被遮罩）；有時限的走
+      // /admin/modbans，那裡才有 duration_s 與到期判定。兩者都會讓 /fire 擋下
+      // 後續訊息，差別在於前者不會自己失效。
+      const r = seconds > 0
+        ? await window.csrfFetch("/admin/modbans", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              target_kind: "fingerprint",
+              target: fp,
+              duration_s: seconds,
+              reason: reason || "",
+              kind: "ban",
+            }),
+          })
+        : await window.csrfFetch("/admin/live/block", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ type: "fingerprint", value: fp, reason: reason || "" }),
+          });
       if (!r.ok) throw new Error("HTTP " + r.status);
-      window.showToast && window.showToast("已封禁 fp:" + fp.slice(0, 8), true);
+      const label = seconds > 0 ? _durationLabel(seconds) : "永久";
+      window.showToast && window.showToast(`已封禁 fp:${fp.slice(0, 8)} · ${label}`, true);
       _closeBanConfirm();
       _close();
     } catch (e) {
@@ -322,10 +346,10 @@
       <div class="admin-bancfm-section">
         <div class="admin-bancfm-sec-label">封禁時長</div>
         <div class="admin-bancfm-duration">
-          <span class="admin-bancfm-dchip is-disabled" title="後端尚未支援時限 ban">1 小時</span>
-          <span class="admin-bancfm-dchip is-disabled" title="後端尚未支援時限 ban">24 小時</span>
-          <span class="admin-bancfm-dchip is-disabled" title="後端尚未支援時限 ban">7 天</span>
-          <span class="admin-bancfm-dchip is-active">永久</span>
+          <span class="admin-bancfm-dchip" role="button" tabindex="0" data-ban-duration="3600">1 小時</span>
+          <span class="admin-bancfm-dchip" role="button" tabindex="0" data-ban-duration="86400">24 小時</span>
+          <span class="admin-bancfm-dchip" role="button" tabindex="0" data-ban-duration="604800">7 天</span>
+          <span class="admin-bancfm-dchip is-active" role="button" tabindex="0" data-ban-duration="0">永久</span>
         </div>
       </div>
       <div class="admin-bancfm-section">
@@ -333,6 +357,24 @@
         <input type="text" class="admin-bancfm-reason" data-ban-reason placeholder="e.g. 持續發送垃圾訊息" maxlength="200" />
       </div>
       <div class="admin-bancfm-warn">⚠ 該指紋下所有訊息將被遮罩，該指紋將被加入黑名單。</div>`;
+
+    // 時長為單選：點一下就把 is-active 移到那顆。鍵盤也要能操作 —— chip 不是
+    // <button>，所以 Enter / Space 要自己接。
+    const _pickDuration = (el) => {
+      body.querySelectorAll(".admin-bancfm-dchip").forEach((c) => c.classList.remove("is-active"));
+      el.classList.add("is-active");
+    };
+    body.addEventListener("click", (e) => {
+      const chip = e.target.closest("[data-ban-duration]");
+      if (chip) _pickDuration(chip);
+    });
+    body.addEventListener("keydown", (e) => {
+      if (e.key !== "Enter" && e.key !== " ") return;
+      const chip = e.target.closest("[data-ban-duration]");
+      if (!chip) return;
+      e.preventDefault();
+      _pickDuration(chip);
+    });
 
     if (!window.HudConfirm) return;
     const ok = await window.HudConfirm.open({
@@ -347,7 +389,9 @@
     });
     if (!ok) return;
     const reason = (body.querySelector("[data-ban-reason]") || {}).value || "";
-    return _banFingerprint(reason.trim());
+    const active = body.querySelector(".admin-bancfm-dchip.is-active");
+    const durationS = active ? parseInt(active.dataset.banDuration || "0", 10) || 0 : 0;
+    return _banFingerprint(reason.trim(), durationS);
   }
   // Stub kept for any straggler call sites that referenced the old close
   // function; HudConfirm now manages its own close lifecycle.

--- a/server/static/js/admin-message-drawer.js
+++ b/server/static/js/admin-message-drawer.js
@@ -277,14 +277,7 @@
 
   // ── ban via existing /admin/live/block ──────────────────────────
 
-  function _durationLabel(seconds) {
-    if (seconds >= 604800) return `${Math.round(seconds / 604800)} 天`;
-    if (seconds >= 86400) return `${Math.round(seconds / 86400)} 天`;
-    if (seconds >= 3600) return `${Math.round(seconds / 3600)} 小時`;
-    return `${seconds} 秒`;
-  }
-
-  async function _banFingerprint(reason, durationS) {
+  async function _banFingerprint(reason, durationS, durationLabel) {
     const fp = _state.entry && _state.entry.data && _state.entry.data.fingerprint;
     if (!fp) return;
     const seconds = parseInt(durationS || 0, 10) || 0;
@@ -310,7 +303,7 @@
             body: JSON.stringify({ type: "fingerprint", value: fp, reason: reason || "" }),
           });
       if (!r.ok) throw new Error("HTTP " + r.status);
-      const label = seconds > 0 ? _durationLabel(seconds) : "永久";
+      const label = durationLabel || (seconds > 0 ? `${seconds} 秒` : "永久");
       window.showToast && window.showToast(`已封禁 fp:${fp.slice(0, 8)} · ${label}`, true);
       _closeBanConfirm();
       _close();
@@ -391,7 +384,10 @@
     const reason = (body.querySelector("[data-ban-reason]") || {}).value || "";
     const active = body.querySelector(".admin-bancfm-dchip.is-active");
     const durationS = active ? parseInt(active.dataset.banDuration || "0", 10) || 0 : 0;
-    return _banFingerprint(reason.trim(), durationS);
+    // 標籤直接用 chip 上的文字，不另外從秒數推算 —— 推算過一次，7 天被算成
+    // 「1 天」（除數誤用 604800），跟 24 小時的提示變得一模一樣。
+    const durationLabel = active ? active.textContent.trim() : "永久";
+    return _banFingerprint(reason.trim(), durationS, durationLabel);
   }
   // Stub kept for any straggler call sites that referenced the old close
   // function; HudConfirm now manages its own close lifecycle.

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -136,6 +136,25 @@ def _isolate_onscreen_limits(tmp_path):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_moderation_bans(tmp_path):
+    """把封禁狀態檔導到 tmp_path 並清掉記憶體快取。
+
+    moderation_bans 現在有自己的 runtime/moderation_bans.json —— 少了這層隔離，
+    任何發出封禁的測試都會寫進正式檔，就跟 api_tokens / danmu_history 之前一樣。
+    """
+    from server.services import moderation_bans
+
+    original = moderation_bans._STATE_FILE
+    moderation_bans._STATE_FILE = tmp_path / "moderation_bans.json"
+    moderation_bans.reset_for_tests()
+    try:
+        yield
+    finally:
+        moderation_bans._STATE_FILE = original
+        moderation_bans.reset_for_tests()
+
+
+@pytest.fixture(autouse=True)
 def _isolate_api_tokens(tmp_path):
     """把 API token 儲存導到 tmp_path。
 

--- a/server/tests/test_ban_enforcement.py
+++ b/server/tests/test_ban_enforcement.py
@@ -1,0 +1,101 @@
+"""時限封禁必須真的擋得住 /fire。
+
+在此之前 moderation_bans 是「有 UI、有 API、有資料模型，但沒有效果」：
+`/admin/modbans` 收得下 duration_s，`is_banned()` 也算得出到期，但 /fire 從來
+沒有呼叫過它 —— 封了照樣送得出彈幕。而且狀態掛在 audit_log 的 500 筆 ring 上，
+封禁會被後續事件擠掉而靜靜失效。
+"""
+
+import time
+
+import pytest
+
+from server.services import moderation_bans
+from server.services.ws_state import update_ws_client_count
+
+
+@pytest.fixture(autouse=True)
+def _overlay_online():
+    """沒有 overlay 連線時 /fire 一律 503，看不出封禁的效果。"""
+    update_ws_client_count(1)
+    yield
+    update_ws_client_count(0)
+
+
+def _fire(client, text="hello", fp="fp_test_sender"):
+    return client.post("/fire", json={"text": text, "fingerprint": fp})
+
+
+def test_unbanned_sender_gets_through(client):
+    assert _fire(client).status_code == 200
+
+
+def test_permanent_ban_blocks_fire(client):
+    moderation_bans.add_ban("fingerprint", "fp_test_sender", duration_s=0, reason="spam")
+    resp = _fire(client)
+    assert resp.status_code == 403, "封禁後仍然送得出彈幕"
+
+
+def test_timed_ban_blocks_while_active(client):
+    moderation_bans.add_ban("fingerprint", "fp_test_sender", duration_s=3600, reason="cooldown")
+    assert _fire(client).status_code == 403
+
+
+def test_timed_ban_expiry_is_evaluated_on_read():
+    """到期判定本身 —— 用 now 參數表達時間推移，不去動全域時鐘。
+
+    早期版本是 monkeypatch time.time 讓時間跳 120 秒。那會讓 scheduler 與
+    rate limiter 一起看到跳躍（它們讀同一個時鐘），代價遠超這條測試的範圍。
+    """
+    meta = moderation_bans.add_ban("fingerprint", "fp_expiry_probe", duration_s=60)
+    expires_at = meta["expires_at"]
+    assert moderation_bans.is_banned("fingerprint", "fp_expiry_probe", now=expires_at - 1) is True
+    assert moderation_bans.is_banned("fingerprint", "fp_expiry_probe", now=expires_at + 1) is False
+
+
+def test_timed_ban_stops_blocking_after_expiry(client):
+    """端對端：短時限封禁到期後 /fire 應該重新放行。
+
+    用真的等待而不是假時鐘 —— 1 秒的封禁，等它自然過期。
+    """
+    moderation_bans.add_ban("fingerprint", "fp_test_sender", duration_s=1, reason="cooldown")
+    assert _fire(client).status_code == 403
+
+    time.sleep(1.2)
+    assert _fire(client).status_code == 200, "封禁到期後仍然被擋"
+
+
+def test_unban_restores_access(client):
+    moderation_bans.add_ban("fingerprint", "fp_test_sender", duration_s=0)
+    assert _fire(client).status_code == 403
+    moderation_bans.remove_ban("fingerprint", "fp_test_sender")
+    assert _fire(client).status_code == 200
+
+
+def test_ban_survives_audit_ring_pressure(client):
+    """封禁不該因為之後發生了很多其他事件就失效。
+
+    舊實作把 audit_log 的 500 筆 ring 當成唯一來源：發一個封禁、再寫 520 筆
+    其他事件，is_banned() 就翻回 False。封禁的有效期應該取決於管理員設的時長，
+    而不是後來系統記了多少事。
+    """
+    from server.services import audit_log
+
+    moderation_bans.add_ban("fingerprint", "fp_test_sender", duration_s=0, reason="spam")
+    for i in range(520):
+        audit_log.append("auth", "login", actor="admin", meta={"i": i})
+
+    assert moderation_bans.is_banned("fingerprint", "fp_test_sender") is True
+    assert _fire(client).status_code == 403, "封禁被無關的 audit 事件洗掉了"
+
+
+def test_ban_state_survives_a_restart(client):
+    """狀態要落地 —— 重啟後封禁仍然有效。"""
+    moderation_bans.add_ban("fingerprint", "fp_test_sender", duration_s=0)
+    moderation_bans.reset_for_tests()  # 模擬行程重啟後重新載入
+    assert moderation_bans.is_banned("fingerprint", "fp_test_sender") is True
+
+
+def test_ip_ban_blocks_fire(client):
+    moderation_bans.add_ban("ip", "127.0.0.1", duration_s=0, reason="abuse")
+    assert _fire(client).status_code == 403

--- a/server/tests/test_moderation_bans.py
+++ b/server/tests/test_moderation_bans.py
@@ -71,20 +71,10 @@ def test_list_active_includes_permanent_and_active():
 def test_list_active_marks_expired():
     """Past expires_at → status='expired' surface for UI."""
     now = time.time()
-    # Manually inject an expired ban event (bypassing add_ban's now+duration_s).
-    audit_log.append(
-        "moderation",
-        "ban",
-        actor="admin",
-        meta={
-            "target_kind": "fingerprint",
-            "target": "expired1",
-            "duration_s": 60,
-            "expires_at": now - 10,
-            "reason": "test",
-        },
-    )
-    rows = moderation_bans.list_active(now=now)
+    # 用真的 add_ban 發一個 60 秒的封禁，再把查詢時間往後推到它之後 —— 比手動
+    # 往 audit_log 塞一筆繞過 add_ban 更貼近真實，也不依賴狀態存在哪裡。
+    moderation_bans.add_ban("fingerprint", "expired1", duration_s=60, reason="test")
+    rows = moderation_bans.list_active(now=now + 120)
     expired_rows = [r for r in rows if r["status"] == "expired"]
     assert any(r["target"] == "expired1" for r in expired_rows)
 

--- a/server/tests/test_overlay_clear.py
+++ b/server/tests/test_overlay_clear.py
@@ -1,0 +1,54 @@
+"""POST /admin/overlay/clear — 清空 overlay 上目前顯示的彈幕。
+
+這個端點在 routes/admin/overlay.py 早就實作完整（廣播 {"type":"clear"}、寫
+audit log、發 on_overlay_clear webhook），overlay.js 與 Electron 的
+child-ws-script.js 也都認得那個訊息 —— 但它一直沒有任何測試，而 admin UI 的
+錯誤分支還寫著「後端尚未實作此端點」。這裡把它釘住。
+"""
+
+import json
+
+from server.services import ws_queue
+
+
+def _login(client):
+    resp = client.post("/login", data={"password": "test"})
+    assert resp.status_code in (200, 302)
+    admin = client.get("/admin/")
+    import re
+
+    m = re.search(r'name="csrf-token"[^>]*content="([^"]+)"', admin.data.decode(), re.S)
+    assert m and m.group(1), "拿不到 CSRF token"
+    return m.group(1)
+
+
+def test_overlay_clear_broadcasts_clear_message(client):
+    """成功時應該把 {"type": "clear"} 推進 ws_queue。"""
+    token = _login(client)
+    ws_queue.dequeue_all()  # 清掉登入過程可能產生的通知
+
+    resp = client.post("/admin/overlay/clear", headers={"X-CSRF-Token": token})
+    assert resp.status_code == 200
+    assert json.loads(resp.data)["status"] == "ok"
+
+    queued = ws_queue.dequeue_all()
+    assert any(m.get("type") == "clear" for m in queued), f"佇列裡沒有 clear 訊息：{queued}"
+
+
+def test_overlay_clear_requires_login(client):
+    resp = client.post("/admin/overlay/clear")
+    assert resp.status_code in (401, 403)
+
+
+def test_overlay_clear_requires_csrf(client):
+    _login(client)
+    resp = client.post("/admin/overlay/clear")  # 不帶 token
+    assert resp.status_code == 403
+
+
+def test_overlay_clear_is_idempotent(client):
+    """連續清兩次不該出錯 —— overlay 端對空畫面是 no-op。"""
+    token = _login(client)
+    for _ in range(2):
+        resp = client.post("/admin/overlay/clear", headers={"X-CSRF-Token": token})
+        assert resp.status_code == 200


### PR DESCRIPTION
封禁的 UI、API、資料模型都在，只是**沒有一條線把它們接起來**。

## 原本的狀況

| 層 | 狀態 |
|---|---|
| `POST /admin/modbans` 收 `duration_s` | ✓ 早就有 |
| `is_banned()` 的到期判定 | ✓ 早就有，docstring 還寫「Lazy check used by the filter pipeline」 |
| **filter pipeline 實際呼叫它** | ✗ **從來沒有** |
| 前端時長 chip | ✗ disabled，寫著「後端尚未支援時限 ban」 |

被封的人照樣送得出彈幕。而前端那句「後端尚未支援」跟事實正好相反。

## 還有一個更嚴重的：封禁會被無關事件洗掉

狀態原本掛在 `audit_log` 的 ring 上，而那個 ring 只保留**跨所有來源**最新的 500 筆。實測：

```
發出永久封禁           → is_banned = True
再寫 520 筆 auth 事件  → is_banned = False   ← 靜靜解封
```

**封禁的實際有效期取決於系統後來記了多少事**，跟管理員設的時長無關。

現在狀態存在 `runtime/moderation_bans.json` + 記憶體 map，`audit_log` 繼續記錄每次動作供稽核。順帶讓熱路徑的檢查從「掃 500 筆事件」變成一次 dict 查詢。

## 接上攔截路徑

`/fire` 在 filter engine **之前**檢查 fingerprint 與 IP——寄件者被封時，內容是什麼都不重要——回 403。

## 前端

三個時長 chip（1 小時 / 24 小時 / 7 天）啟用，單選、可鍵盤操作。有時限走 `/admin/modbans`，永久維持 `/admin/live/block`（訊息遮罩行為不變）。Toast 會說明套用的是哪一種。

## 驗證

9 條測試，兩個 mutation：

- 移除 `/fire` 的檢查 → **6 條紅**
- `is_banned` 改回讀 audit ring → **4 條紅**（含「封禁不該被無關事件洗掉」那條）

`conftest` 補了 `_isolate_moderation_bans`——新的持久化檔就是新的污染目標，跟 `api_tokens`、`danmu_history` 是同一課。

### 一條我自己寫錯的測試

到期驗證的第一版 `monkeypatch` 了**全域 `time.time`** 讓時間跳 120 秒——scheduler 和 rate limiter 讀的是同一個時鐘。拆成用 `now=` 參數測判定邏輯、用真實 1 秒等待測端對端。

## 順帶修掉一句謊話（`ee9b047`）

`/admin/overlay/clear` 的前端在任何非 2xx 時說「後端尚未實作此端點」。那個端點一直都在（廣播 `{"type":"clear"}` + audit + webhook），兩個 overlay 實作也都認得。純粹是沒更新的舊文案，把人指向錯的方向。**該端點零測試覆蓋**——大概就是錯訊息能活這麼久的原因，現在補了 4 條。

## 測試耗時說明

本機跑全套是 **1322 passed / 約 11 分鐘**，比稍早的 4 分半久。查證後與本 PR 無關：

- `test_api_errors.py` 改動前後 3.96s vs 4.04s
- `test_system_ws.py` 改動前後 63.98s vs 64.43s
- 最慢的 25 個測試全是既有的 WS / e2e（各約 10s 的固定逾時），本 PR 最慢的一條 1.26s
- 當下機器 `load average 16–20`，CPU 卻只有 18%

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permanent and time-limited fingerprint ban options in the moderation interface.
  * Added support for enforcing bans by fingerprint and IP address before messages are processed.
  * Ban status now persists across restarts and remains reliable as audit history grows.
  * Expired timed bans automatically stop blocking access.

* **Bug Fixes**
  * Improved error messaging when clearing the desktop overlay fails.
  * Improved overlay-clear behavior and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->